### PR TITLE
fix: output assets should have filename extension by default

### DIFF
--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -8,8 +8,7 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    trace::TraceRawVcs, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, Upcast, Value,
-    ValueToString, Vc,
+    trace::TraceRawVcs, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, Upcast, Value, ValueToString, Vc
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::{hash_xxh3_hash64, DeterministicHash};
@@ -475,7 +474,10 @@ impl ChunkingContext for BrowserChunkingContext {
                         };
                         Ok(chunk_root.join(filename.into()))
                     }
-                    None => Ok(chunk_root.join(name)),
+                    None => {
+                        let name = format!("{}.{}", name, extension);
+                        Ok(chunk_root.join(name.into()))
+                    },
                 }
             }
             None => Ok(chunk_root.join(import_name)),
@@ -762,19 +764,19 @@ impl ChunkingContext for BrowserChunkingContext {
 pub async fn ident_to_output_filename(
     ident: Vc<AssetIdent>,
     context_path: Vc<FileSystemPath>,
-    expected_extension: RcStr,
+    _expected_extension: RcStr,
 ) -> Result<Vc<RcStr>> {
     let ident = &*ident.await?;
     let path = &*ident.path.await?;
-    let mut name = if let Some(inner) = context_path.await?.get_path_to(path) {
+    let name = if let Some(inner) = context_path.await?.get_path_to(path) {
         clean_separators(inner)
     } else {
         clean_separators(&ident.path.to_string().await?)
     };
-    let removed_extension = name.ends_with(&*expected_extension);
-    if removed_extension {
-        name.truncate(name.len() - expected_extension.len());
-    }
+    // let removed_extension = name.ends_with(&*expected_extension);
+    // if removed_extension {
+    //     name.truncate(name.len() - expected_extension.len());
+    // }
     // name += &expected_extension;
     Ok(Vc::cell(name.into()))
 }

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -475,7 +475,7 @@ impl ChunkingContext for BrowserChunkingContext {
                         Ok(chunk_root.join(filename.into()))
                     }
                     None => {
-                        let name = format!("{}.{}", name, extension);
+                        let name = format!("{}{}", name, extension);
                         Ok(chunk_root.join(name.into()))
                     },
                 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

ref issue: https://github.com/umijs/mako/issues/1902

I just test at my local: 

The case with default output options:

![image](https://github.com/user-attachments/assets/96914d14-df1c-472d-a3e2-db8f741b31ad)

And the case with filename template:

![image](https://github.com/user-attachments/assets/980dbca0-934e-4f3e-b34b-dbfc02540e61)

Both work fine
