### PR TITLE
feat: externalType support global

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -448,6 +448,7 @@ pub enum ExternalType {
     Url,
     CommonJs,
     EcmaScriptModule,
+    Global,
 }
 
 impl Display for ExternalType {
@@ -456,6 +457,7 @@ impl Display for ExternalType {
             ExternalType::CommonJs => write!(f, "commonjs"),
             ExternalType::EcmaScriptModule => write!(f, "esm"),
             ExternalType::Url => write!(f, "url"),
+            ExternalType::Global => write!(f, "global"),
         }
     }
 }
@@ -2776,6 +2778,7 @@ async fn resolve_import_map_result(
                         ExternalType::EcmaScriptModule => {
                             node_esm_resolve_options(alias_lookup_path.root())
                         }
+                        ExternalType::Global => options,
                     },
                 )
                 .await?

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -49,6 +49,7 @@ pub enum CachedExternalType {
     CommonJs,
     EcmaScriptViaRequire,
     EcmaScriptViaImport,
+    Global,
 }
 
 impl Display for CachedExternalType {
@@ -57,6 +58,7 @@ impl Display for CachedExternalType {
             CachedExternalType::CommonJs => write!(f, "cjs"),
             CachedExternalType::EcmaScriptViaRequire => write!(f, "esm_require"),
             CachedExternalType::EcmaScriptViaImport => write!(f, "esm_import"),
+            CachedExternalType::Global => write!(f, "global"),
         }
     }
 }
@@ -87,19 +89,31 @@ impl CachedExternalModule {
     pub fn content(&self) -> Result<Vc<EcmascriptModuleContent>> {
         let mut code = RopeBuilder::default();
 
-        if self.external_type == CachedExternalType::EcmaScriptViaImport {
-            writeln!(
-                code,
-                "const mod = await {TURBOPACK_EXTERNAL_IMPORT}({});",
-                StringifyJs(&self.request)
-            )?;
-        } else {
-            writeln!(
-                code,
-                "const mod = {TURBOPACK_EXTERNAL_REQUIRE}({}, () => require({}));",
-                StringifyJs(&self.request),
-                StringifyJs(&self.request)
-            )?;
+        match self.external_type {
+            CachedExternalType::EcmaScriptViaImport => {
+                writeln!(
+                    code,
+                    "const mod = await {TURBOPACK_EXTERNAL_IMPORT}({});",
+                    StringifyJs(&self.request)
+                )?;
+            }
+            CachedExternalType::Global => {
+                writeln!(
+                    code,
+                    // TODO: change after v15.4
+                    // the latest code of turbopack remove the global access: https://github.com/vercel/next.js/blob/canary/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs#L90
+                    "const mod = global[{}];",
+                    StringifyJs(&self.request)
+                )?;
+            }
+            _ => {
+                writeln!(
+                    code,
+                    "const mod = {TURBOPACK_EXTERNAL_REQUIRE}({}, () => require({}));",
+                    StringifyJs(&self.request),
+                    StringifyJs(&self.request)
+                )?;
+            }
         }
 
         writeln!(code)?;

--- a/turbopack/crates/turbopack-ecmascript/src/runtime_functions.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/runtime_functions.rs
@@ -78,10 +78,12 @@ pub const TURBOPACK_REQUIRE_STUB: &TurbopackRuntimeFunctionShortcut =
     &TurbopackRuntimeFunctionShortcut::new("__turbopack_context__.z", "z");
 pub const TURBOPACK_REQUIRE_REAL: &TurbopackRuntimeFunctionShortcut =
     &TurbopackRuntimeFunctionShortcut::new("__turbopack_context__.t", "t");
+pub const TURBOPACK_GLOBAL_ACCESS: &TurbopackRuntimeFunctionShortcut =
+    &TurbopackRuntimeFunctionShortcut::new("__turbopack_context__.g", "g");
 
 /// Adding an entry to this list will automatically ensure that `__turbopack_XXX__` can be called
 /// from user code (by inserting a replacement into free_var_references)
-pub const TUBROPACK_RUNTIME_FUNCTION_SHORTCUTS: [(&str, &TurbopackRuntimeFunctionShortcut); 21] = [
+pub const TUBROPACK_RUNTIME_FUNCTION_SHORTCUTS: [(&str, &TurbopackRuntimeFunctionShortcut); 22] = [
     ("__turbopack_require__", TURBOPACK_REQUIRE),
     ("__turbopack_module_context__", TURBOPACK_MODULE_CONTEXT),
     ("__turbopack_import__", TURBOPACK_IMPORT),
@@ -109,4 +111,5 @@ pub const TUBROPACK_RUNTIME_FUNCTION_SHORTCUTS: [(&str, &TurbopackRuntimeFunctio
     ("__turbopack_refresh__", TURBOPACK_REFRESH),
     ("__turbopack_require_stub__", TURBOPACK_REQUIRE_STUB),
     ("__turbopack_require_real__", TURBOPACK_REQUIRE_REAL),
+    ("__turbopack_global_access__", TURBOPACK_GLOBAL_ACCESS),
 ];

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -674,6 +674,7 @@ async fn externals_tracing_module_context(ty: ExternalType) -> Result<Vc<ModuleA
             ExternalType::CommonJs => vec!["require".into()],
             ExternalType::EcmaScriptModule => vec!["import".into()],
             ExternalType::Url => vec![],
+            ExternalType::Global => vec![],
         },
         ..Default::default()
     };
@@ -994,6 +995,7 @@ pub async fn replace_external(
                 CachedExternalType::EcmaScriptViaRequire
             }
         }
+        ExternalType::Global => CachedExternalType::Global,
         ExternalType::Url => {
             // we don't want to wrap url externals.
             return Ok(None);


### PR DESCRIPTION
Now turbopack's externalType only support the following types:

- CommonJs 
- EcmaScriptModule
- Url(seems not be supported completely)

The type `CommonJs` and `EcmaScriptModule` only support to use `require()` or `import()` to deal the external module(it's friendly to the NodeJS or Edege Runtime enviroment, seems not friendly to the browser enviroment), so meybe we can support the externalType like 'global'(https://webpack.js.org/configuration/externals/#externalstypeglobal) or other externalType like https://webpack.js.org/configuration/externals/#externalstypevar, which can help us to set the external module into a global var.