### PR TITLE
feat(turbpokack): normalize chunk path in runtime chunk registry

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/runtime-base.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/runtime-base.ts
@@ -21,6 +21,19 @@ declare var TURBOPACK_NEXT_CHUNK_URLS: ChunkUrl[] | undefined;
 declare var CHUNK_BASE_PATH: string;
 declare var CHUNK_SUFFIX_PATH: string;
 
+function normalizeChunkPath(path: string) {
+  if (path.startsWith("./")) {
+      path = path.substring(2);
+  }
+  if (!path.endsWith("/")) {
+      path = path.concat("/");
+  }
+  return path;
+}
+
+const NORMED_CHUNK_BASE_PATH = normalizeChunkPath(CHUNK_BASE_PATH);
+const NORMED_CHUNK_SUFFIX_PATH = normalizeChunkPath(CHUNK_SUFFIX_PATH);
+
 // Provided by build or dev base
 declare function instantiateModule(id: ModuleId, source: SourceInfo): Module;
 
@@ -308,10 +321,10 @@ function instantiateRuntimeModule(
  * Returns the URL relative to the origin where a chunk can be fetched from.
  */
 function getChunkRelativeUrl(chunkPath: ChunkPath | ChunkListPath): ChunkUrl {
-  return `${CHUNK_BASE_PATH}${chunkPath
+  return `${NORMED_CHUNK_BASE_PATH}${chunkPath
     .split("/")
     .map((p) => encodeURIComponent(p))
-    .join("/")}${CHUNK_SUFFIX_PATH}` as ChunkUrl;
+    .join("/")}${NORMED_CHUNK_SUFFIX_PATH}` as ChunkUrl;
 }
 
 /**
@@ -323,11 +336,14 @@ function getPathFromScript(chunkScript: ChunkPath | ChunkListPath | ChunkScript 
   if (typeof chunkScript === "string") {
     return chunkScript as ChunkPath | ChunkListPath;
   }
-  const chunkUrl = typeof TURBOPACK_NEXT_CHUNK_URLS !== "undefined"
+  let chunkUrl = typeof TURBOPACK_NEXT_CHUNK_URLS !== "undefined"
     ? TURBOPACK_NEXT_CHUNK_URLS.pop()!
     : chunkScript.getAttribute("src")!;
+  if (chunkUrl.startsWith("./")) {
+    chunkUrl = chunkUrl.substring(2);
+  }
   const src = decodeURIComponent(chunkUrl.replace(/[?#].*$/, ""));
-  const path = src.startsWith(CHUNK_BASE_PATH) ? src.slice(CHUNK_BASE_PATH.length) : src;
+  const path = src.startsWith(NORMED_CHUNK_BASE_PATH) ? src.slice(NORMED_CHUNK_BASE_PATH.length) : src;
   return path as ChunkPath | ChunkListPath;
 }
 

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/dev-backend-dom.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/dev-backend-dom.ts
@@ -112,7 +112,7 @@ let DEV_BACKEND: DevRuntimeBackend;
 
 function _eval({ code, url, map }: EcmascriptModuleEntry): ModuleFactory {
   code += `\n\n//# sourceURL=${encodeURI(
-    location.origin + CHUNK_BASE_PATH + url + CHUNK_SUFFIX_PATH
+    location.origin + NORMED_CHUNK_BASE_PATH + normalizeChunPath(url) + NORMED_CHUNK_SUFFIX_PATH
   )}`;
   if (map) {
     code += `\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${btoa(


### PR DESCRIPTION
## Why
Fix a problem of that when 
```js
CHUNK_BASE_PATH = "./dist" 
```

and script tag add in HTML is 
```html
<script src="dist/chunk.js"></script>
```
The `dist/chunk.js` chunk will never being resolved after script loaded. 

## How
Just erasing out differences of `./` prefix and `/` suffix.

## Can be upstreamed?
True