### PR TITLE
chore(turbopack): css chunk ident execute wrong method

### DIFF
--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -160,7 +160,7 @@ impl CssChunk {
 
             let mut hasher = Xxh3Hash64Hasher::new();
             chunk_item_idents.iter().for_each(|ident| {
-                ident.ddeterministic_hash(&mut hash);
+                ident.deterministic_hash(&mut hasher);
             });
 
             let hash = hasher.finish();


### PR DESCRIPTION
following: https://github.com/umijs/next.js/pull/14

![image](https://github.com/user-attachments/assets/e0773442-3888-47f9-88f3-d4d4b705545e)