### PR TITLE
feat(turbopack): support more types of compile time define env

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -1,4 +1,4 @@
-use std::iter::once;
+use std::{iter::once, str::FromStr};
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
@@ -80,11 +80,10 @@ fn defines(define_env: &FxIndexMap<RcStr, RcStr>) -> CompileTimeDefines {
                     .collect::<Vec<_>>(),
             )
             .or_insert_with(|| {
-                let val = serde_json::from_str(v);
+                let val = serde_json::Value::from_str(v);
                 match val {
-                    Ok(serde_json::Value::Bool(v)) => CompileTimeDefineValue::Bool(v),
-                    Ok(serde_json::Value::String(v)) => CompileTimeDefineValue::String(v.into()),
-                    _ => CompileTimeDefineValue::JSON(v.clone()),
+                    Ok(v) => v.into(),
+                    _ => CompileTimeDefineValue::Unknown(v.clone()),
                 }
             });
     }

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -44,11 +44,10 @@ fn defines(define_env: &FxIndexMap<RcStr, RcStr>) -> CompileTimeDefines {
                     .collect::<Vec<_>>(),
             )
             .or_insert_with(|| {
-                let val = serde_json::from_str(v);
+                let val = serde_json::from_str::<serde_json::Value>(v);
                 match val {
-                    Ok(serde_json::Value::Bool(v)) => CompileTimeDefineValue::Bool(v),
-                    Ok(serde_json::Value::String(v)) => CompileTimeDefineValue::String(v.into()),
-                    _ => CompileTimeDefineValue::JSON(v.clone()),
+                    Ok(v) => v.into(),
+                    _ => CompileTimeDefineValue::Unknown(v.clone()),
                 }
             });
     }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1,4 +1,4 @@
-use std::iter::once;
+use std::{iter::once, str::FromStr};
 
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
@@ -354,11 +354,10 @@ fn defines(define_env: &FxIndexMap<RcStr, RcStr>) -> CompileTimeDefines {
                     .collect::<Vec<_>>(),
             )
             .or_insert_with(|| {
-                let val = serde_json::from_str(v);
+                let val = serde_json::Value::from_str(v);
                 match val {
-                    Ok(serde_json::Value::Bool(v)) => CompileTimeDefineValue::Bool(v),
-                    Ok(serde_json::Value::String(v)) => CompileTimeDefineValue::String(v.into()),
-                    _ => CompileTimeDefineValue::JSON(v.clone()),
+                    Ok(v) => v.into(),
+                    _ => CompileTimeDefineValue::Unknown(v.clone()),
                 }
             });
     }

--- a/turbopack/crates/turbo-tasks/src/marker_trait.rs
+++ b/turbopack/crates/turbo-tasks/src/marker_trait.rs
@@ -40,7 +40,7 @@ macro_rules! impl_auto_marker_trait {
         $crate::marker_trait::impl_marker_trait!($trait: ::std::path::Path, ::std::path::PathBuf);
         $crate::marker_trait::impl_marker_trait!(
             $trait:
-            ::serde_json::Value, ::serde_json::Map<String, ::serde_json::Value>
+            ::serde_json::Value, ::serde_json::Map<String, ::serde_json::Value>, ::serde_json::Number,
         );
 
         $crate::marker_trait::impl_marker_trait_fn_ptr!($trait: E D C B A Z Y X W V U T);
@@ -122,7 +122,7 @@ macro_rules! impl_marker_trait_fn_ptr {
 
 /// Create an implementation for every possible tuple where every element implements `$trait`.
 ///
-/// Must be passed a sequence of identifier fo the tuple's generic parameters. This will only
+/// Must be passed a sequence of identifier to the tuple's generic parameters. This will only
 /// generate implementations up to the length of the passed in sequence.
 ///
 /// Based on stdlib's internal `tuple_impls!` macro.

--- a/turbopack/crates/turbo-tasks/src/trace.rs
+++ b/turbopack/crates/turbo-tasks/src/trace.rs
@@ -77,7 +77,7 @@ ignore!(
 );
 ignore!((), str, String, Duration, anyhow::Error, RcStr);
 ignore!(Path, PathBuf);
-ignore!(serde_json::Value, serde_json::Map<String, serde_json::Value>);
+ignore!(serde_json::Value, serde_json::Map<String, serde_json::Value>, serde_json::Number);
 
 impl<T: ?Sized> TraceRawVcs for PhantomData<T> {
     fn trace_raw_vcs(&self, _trace_context: &mut TraceRawVcsContext) {}

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -1,4 +1,9 @@
 use anyhow::Result;
+use swc_core::{
+    common::DUMMY_SP,
+    ecma::ast::{ArrayLit, Expr, KeyValueProp, ObjectLit, Prop, PropName, Str},
+    quote,
+};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
@@ -103,9 +108,13 @@ macro_rules! free_var_references {
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub enum CompileTimeDefineValue {
+    Null,
     Bool(bool),
+    Number(serde_json::Number),
     String(RcStr),
-    JSON(RcStr),
+    Array(Vec<CompileTimeDefineValue>),
+    Object(Vec<(RcStr, CompileTimeDefineValue)>),
+    Unknown(RcStr),
 }
 
 impl From<bool> for CompileTimeDefineValue {
@@ -134,7 +143,64 @@ impl From<&str> for CompileTimeDefineValue {
 
 impl From<serde_json::Value> for CompileTimeDefineValue {
     fn from(value: serde_json::Value) -> Self {
-        Self::JSON(value.to_string().into())
+        match value {
+            serde_json::Value::Null => Self::Null,
+            serde_json::Value::Bool(b) => Self::Bool(b),
+            serde_json::Value::Number(n) => Self::Number(n.clone()),
+            serde_json::Value::String(s) => Self::String(s.into()),
+            serde_json::Value::Array(a) => Self::Array(a.into_iter().map(|i| i.into()).collect()),
+            serde_json::Value::Object(m) => {
+                Self::Object(m.into_iter().map(|(k, v)| (k.into(), v.into())).collect())
+            }
+        }
+    }
+}
+
+impl From<CompileTimeDefineValue> for Expr {
+    fn from(value: CompileTimeDefineValue) -> Self {
+        match value {
+            CompileTimeDefineValue::Null => {
+                quote!("(\"TURBOPACK compile-time value\", null)" as Expr)
+            }
+            CompileTimeDefineValue::Bool(true) => {
+                quote!("(\"TURBOPACK compile-time value\", true)" as Expr)
+            }
+            CompileTimeDefineValue::Bool(false) => {
+                quote!("(\"TURBOPACK compile-time value\", false)" as Expr)
+            }
+            CompileTimeDefineValue::Number(ref n) => {
+                quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = n.as_f64().unwrap().into())
+            }
+            CompileTimeDefineValue::String(ref s) => {
+                quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = s.to_string().into())
+            }
+            CompileTimeDefineValue::Array(a) => {
+                quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = Expr::Array(ArrayLit {
+                    span: DUMMY_SP,
+                    elems: a.into_iter().map(|i| Some(Expr::from(i).into())).collect(),
+                }))
+            }
+            CompileTimeDefineValue::Object(m) => {
+                quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = Expr::Object(ObjectLit {
+                    span: DUMMY_SP,
+                    props: m
+                        .into_iter()
+                        .map(|(k, v)| {
+                            swc_core::ecma::ast::PropOrSpread::Prop(
+                                Prop::KeyValue(KeyValueProp {
+                                    key: PropName::Str(Str::from(k.as_str())),
+                                    value: Expr::from(v).into(),
+                                })
+                                .into(),
+                            )
+                        })
+                        .collect(),
+                }))
+            }
+            CompileTimeDefineValue::Unknown(ref s) => {
+                quote!("(\"TURBOPACK compile-time value\", JSON.parse($e))" as Expr, e: Expr = s.to_string().into())
+            }
+        }
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -28,7 +28,7 @@ petgraph = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["arbitrary_precision"] }
 sourcemap = { workspace = true }
 smallvec = { workspace = true }
 strsim = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -577,9 +577,26 @@ impl From<ConstantValue> for JsValue {
 impl From<&CompileTimeDefineValue> for JsValue {
     fn from(v: &CompileTimeDefineValue) -> Self {
         match v {
-            CompileTimeDefineValue::String(s) => JsValue::Constant(s.as_str().into()),
+            CompileTimeDefineValue::Null => JsValue::Constant(ConstantValue::Null),
             CompileTimeDefineValue::Bool(b) => JsValue::Constant((*b).into()),
-            CompileTimeDefineValue::JSON(_) => {
+            CompileTimeDefineValue::Number(n) => {
+                JsValue::Constant(ConstantValue::Num(ConstantNumber(n.as_f64().unwrap())))
+            }
+            CompileTimeDefineValue::String(s) => JsValue::Constant(s.as_str().into()),
+            CompileTimeDefineValue::Array(a) => JsValue::Array {
+                total_nodes: a.len() as u32,
+                items: a.iter().map(Into::into).collect(),
+                mutable: false,
+            },
+            CompileTimeDefineValue::Object(m) => JsValue::Object {
+                total_nodes: m.len() as u32,
+                parts: m
+                    .iter()
+                    .map(|(k, v)| ObjectPart::KeyValue(k.clone().into(), v.into()))
+                    .collect(),
+                mutable: false,
+            },
+            CompileTimeDefineValue::Unknown(_) => {
                 JsValue::unknown_empty(false, "compile time injected JSON")
             }
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use swc_core::quote;
 use turbo_tasks::{debug::ValueDebugFormat, trace::TraceRawVcs, NonLocalValue, Value, Vc};
 use turbopack_core::{
     chunk::ChunkingContext, compile_time_info::CompileTimeDefineValue, module_graph::ModuleGraph,
@@ -33,12 +32,8 @@ impl ConstantValueCodeGen {
         let value = self.value.clone();
 
         let visitor = create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
-            *expr = match value {
-                CompileTimeDefineValue::Bool(true) => quote!("(\"TURBOPACK compile-time value\", true)" as Expr),
-                CompileTimeDefineValue::Bool(false) => quote!("(\"TURBOPACK compile-time value\", false)" as Expr),
-                CompileTimeDefineValue::String(ref s) => quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = s.to_string().into()),
-                CompileTimeDefineValue::JSON(ref s) => quote!("(\"TURBOPACK compile-time value\", JSON.parse($e))" as Expr, e: Expr = s.to_string().into()),
-            };
+            // TODO: avoid this clone
+            *expr = value.clone().into();
         });
 
         Ok(CodeGeneration::visitors(vec![visitor]))


### PR DESCRIPTION
## What
Let compile-time define env supports full types of JSON. 

This may also improve the minification  because more static informations being provided when handling define env.

PR to upstream: https://github.com/vercel/next.js/pull/81042.

The evaluated define value like `"1 + 1"`  is not supported still.