### PR TITLE
feat(turbopack): improve compile-time define value to support more data types and expr evaluation

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -1,8 +1,6 @@
 use std::{
     iter,
     mem::{replace, take},
-    path::PathBuf,
-    str::FromStr,
     sync::Arc,
 };
 
@@ -12,7 +10,7 @@ use swc_core::{
     atoms::Atom,
     base::try_with_handler,
     common::{
-        GLOBALS, Mark, SourceMap, Span, Spanned, SyntaxContext, comments::Comments,
+        FileName, GLOBALS, Mark, SourceMap, Span, Spanned, SyntaxContext, comments::Comments,
         pass::AstNodePath, sync::Lrc,
     },
     ecma::{
@@ -731,14 +729,7 @@ impl EvalContext {
 
     pub fn eval_single_expr_lit(expr_lit: RcStr) -> Result<JsValue> {
         let cm = Lrc::new(SourceMap::default());
-        let fm = cm.new_source_file(
-            Lrc::new(
-                PathBuf::from_str("__eval_single_expr_lit_internal__.js")
-                    .unwrap()
-                    .into(),
-            ),
-            expr_lit.clone(),
-        );
+        let fm = cm.new_source_file(FileName::Anon.into(), expr_lit.clone());
 
         let js_value = try_with_handler(cm, Default::default(), |handler| {
             GLOBALS.set(&Default::default(), || {

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -1,9 +1,7 @@
-use std::{path::PathBuf, str::FromStr};
-
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use swc_core::{
-    common::{DUMMY_SP, SourceMap, sync::Lrc},
+    common::{DUMMY_SP, FileName, SourceMap, sync::Lrc},
     ecma::{
         ast::{ArrayLit, EsVersion, Expr, KeyValueProp, ObjectLit, Prop, PropName, Str},
         parser::{Syntax, parse_file_as_expr},
@@ -112,14 +110,7 @@ fn define_env_to_expr(value: CompileTimeDefineValue) -> Expr {
 
 fn parse_single_expr_lit(expr_lit: RcStr) -> Expr {
     let cm = Lrc::new(SourceMap::default());
-    let fm = cm.new_source_file(
-        Lrc::new(
-            PathBuf::from_str("__parse_expr_lit_internal__.js")
-                .unwrap()
-                .into(),
-        ),
-        expr_lit.clone(),
-    );
+    let fm = cm.new_source_file(FileName::Anon.into(), expr_lit.clone());
     parse_file_as_expr(
         &fm,
         Syntax::Es(Default::default()),


### PR DESCRIPTION
## What
Let compile-time define env supports full types of json and basical evaluation. See examples at

https://github.com/umijs/next.js/blob/feat/upstream-turboapack-define-env/turbopack/crates/turbopack-tests/tests/snapshot.rs#L261-L286

This may also improve the minification  because more static informations being provided when handling define env. But this change may affect the ecmascript analysis and tree-shaking, so need a careful review.
