### PR TITLE
fix(turbopack): external export should compitable to all types

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -28,8 +28,8 @@ use crate::{
     },
     references::async_module::{AsyncModule, OptionAsyncModule},
     runtime_functions::{
-        TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_EXTERNAL_IMPORT, TURBOPACK_EXTERNAL_REQUIRE,
-        TURBOPACK_LOAD_BY_URL,
+        TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_EXPORT_VALUE, TURBOPACK_EXTERNAL_IMPORT,
+        TURBOPACK_EXTERNAL_REQUIRE, TURBOPACK_LOAD_BY_URL,
     },
     utils::StringifyJs,
 };
@@ -221,8 +221,12 @@ impl CachedExternalModule {
 
         if self.external_type == CachedExternalType::CommonJs {
             writeln!(code, "module.exports = mod;")?;
-        } else {
+        } else if self.external_type == CachedExternalType::EcmaScriptViaImport
+            || self.external_type == CachedExternalType::EcmaScriptViaRequire
+        {
             writeln!(code, "{TURBOPACK_EXPORT_NAMESPACE}(mod);")?;
+        } else {
+            writeln!(code, "{TURBOPACK_EXPORT_VALUE}(mod);")?;
         }
 
         Ok(EcmascriptModuleContent {


### PR DESCRIPTION
问题背景: turbopack 在设计 external_module 这个模块的时候，只考虑到了 CJS 和 ESM 两种规范，在之前 utoopack 支持其他的 external_type 的时候，默认将导出处理成了最早 turbopack 处理 ESM 的分支，大概的导出伪代码如下:

```ts
module.exports = module.namespaceObject = exportMod;
```

然后在编译 import 导入模块的时候，对应的 `esmImport` 运行时函数中会直接判断 `module.namespaceObject` 存不存在，如果存在就直接把 `exportMod` 给返回回去，然后调用的时候根据 external 依赖的导入方式去做对应的处理，例如:

```ts
import React from 'react'

console.log(React.version)
```

会处理成:

```ts
console.log(_external_module_react_["default"]);
```

正常情况下，react 有 esm 导出，这里取 `default` 是 ok 的。但如果这里 react external 出去，用户注入了一个 umd 的 react 产物进来(可以理解成 cjs ，没有 default 导出)，那之前 external 的处理这里就有问题了(上面的 console.log 输出会是 undefined)。

因此这个 pr 为了修复上面这个问题。

修复方式其实就是把之前 esm 导出方法在非明确 ESM 场景用类似的 CJS 导出，即这次 PR 中的 `exportValue` 方法，它的代码大概如下:

```ts
module.exports = exportMod
```

这样在做导入的时候，`esmImport` 判断不到 `module.namespaceObject` 会直接按照标准的 esmInterOp 去处理:

<img width="1576" height="1242" alt="image" src="https://github.com/user-attachments/assets/46bade99-0103-4561-9c98-28b7f71bfb47" />

后续的处理流程就跟正常 webpack 的处理方式类似了。
