### PR TITLE
feat: ruleCondition support query condition

### DIFF
--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -45,6 +45,10 @@ pub enum RuleCondition {
         glob: ReadRef<Glob>,
     },
     ResourceBasePathGlob(#[turbo_tasks(trace_ignore)] ReadRef<Glob>),
+    ResourceQueryContains {
+        extension: String,
+        query: String,
+    },
 }
 
 impl RuleCondition {
@@ -281,6 +285,10 @@ impl RuleCondition {
                             }
                             FileContent::NotFound => return Ok(false),
                         }
+                    }
+                    RuleCondition::ResourceQueryContains { extension, query } => {
+                        let ident = source.ident().await?;
+                        return Ok(path.path.ends_with(extension) && ident.query.contains(query));
                     }
                 }
             }


### PR DESCRIPTION
module 的 rule condition 能支持匹配带 query 的语句，举个例子，去 match 这样的 query 代码:

```ts
import styles from './index.less?modules' 
```

rust 侧的代码匹配:

```rs
RuleCondition::ResourceQueryContains {
    extension: ".less".into(),
    query: "?modules".into(),
},
```