### PR TITLE
fix(turbopack): remove css chunk prefix under devRuntime

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/dev-backend-dom.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/dev-backend-dom.ts
@@ -51,13 +51,14 @@ let DEV_BACKEND: DevRuntimeBackend
           return
         }
 
-        const decodedChunkUrl = decodeURI(chunkUrl)
+        const withoutNormalizedChunkUrl = chunkUrl.replace(NORMALIZED_CHUNK_BASE_PATH, '/')
+        const decodedChunkUrl = decodeURI(withoutNormalizedChunkUrl)
         const previousLinks = document.querySelectorAll(
-          `link[rel=stylesheet][href="${chunkUrl}"],link[rel=stylesheet][href^="${chunkUrl}?"],link[rel=stylesheet][href="${decodedChunkUrl}"],link[rel=stylesheet][href^="${decodedChunkUrl}?"]`
+          `link[rel=stylesheet][href="${decodedChunkUrl}"],link[rel=stylesheet][href^="${decodedChunkUrl}?"],link[rel=stylesheet][href="${withoutNormalizedChunkUrl}"],link[rel=stylesheet][href^="${withoutNormalizedChunkUrl}?"]`
         )
 
         if (previousLinks.length === 0) {
-          reject(new Error(`No link element found for chunk ${chunkUrl}`))
+          reject(new Error(`No link element found for chunk ${withoutNormalizedChunkUrl}`))
           return
         }
 
@@ -72,9 +73,9 @@ let DEV_BACKEND: DevRuntimeBackend
           //
           // Safari has a similar issue, but only if you have a `<link rel=preload ... />` tag
           // pointing to the same URL as the stylesheet: https://bugs.webkit.org/show_bug.cgi?id=187726
-          link.href = `${chunkUrl}?ts=${Date.now()}`
+          link.href = `${withoutNormalizedChunkUrl}?ts=${Date.now()}`
         } else {
-          link.href = chunkUrl
+          link.href = withoutNormalizedChunkUrl
         }
 
         link.onerror = () => {


### PR DESCRIPTION
closes: https://github.com/utooland/utoo/issues/2187

调整一下 css 更改时 reload chunk 的 url(目前看来  dev 的时候没必要添加 NORMALIZED_CHUNK_PATH，这里值应该是 `/dist`)，可能还会有一些其他的方法需要调整，未来遇到具体的 case 再修复:


https://github.com/user-attachments/assets/c5ecb087-34f6-405f-ad46-381609c77fbd