### PR TITLE
fix(turbopack-css): ignore lightning-css global pseudo elements warning

### DIFF
--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -468,7 +468,17 @@ async fn process_content(
                 // `.await` in the loop.
                 let warnings = warnings.read().unwrap().iter().cloned().collect::<Vec<_>>();
                 for err in warnings.iter() {
-                    match err.kind {
+                    // Ignore :global pseudo-class errors from preprocessors like LESS
+                    if let lightningcss::error::ParserError::SelectorError(
+                        lightningcss::error::SelectorError::UnsupportedPseudoClass(name),
+                    ) = &err.kind
+                    {
+                        if name.as_ref() == "global" {
+                            continue;
+                        }
+                    }
+
+                    match &err.kind {
                         lightningcss::error::ParserError::UnexpectedToken(_)
                         | lightningcss::error::ParserError::UnexpectedImportRule
                         | lightningcss::error::ParserError::SelectorError(..)
@@ -495,7 +505,7 @@ async fn process_content(
                         }
 
                         _ => {
-                            // Ignore
+                            // Ignore other warnings
                         }
                     }
                 }

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -468,17 +468,13 @@ async fn process_content(
                 // `.await` in the loop.
                 let warnings = warnings.read().unwrap().iter().cloned().collect::<Vec<_>>();
                 for err in warnings.iter() {
-                    // Ignore :global pseudo-class errors from preprocessors like LESS
-                    if let lightningcss::error::ParserError::SelectorError(
-                        lightningcss::error::SelectorError::UnsupportedPseudoClass(name),
-                    ) = &err.kind
-                    {
-                        if name.as_ref() == "global" {
+                    match &err.kind {
+                        // Ignore :global pseudo-class errors from preprocessors like LESS
+                        lightningcss::error::ParserError::SelectorError(
+                            lightningcss::error::SelectorError::UnsupportedPseudoClass(name),
+                        ) if name.as_ref() == "global" => {
                             continue;
                         }
-                    }
-
-                    match &err.kind {
                         lightningcss::error::ParserError::UnexpectedToken(_)
                         | lightningcss::error::ParserError::UnexpectedImportRule
                         | lightningcss::error::ParserError::SelectorError(..)


### PR DESCRIPTION
for issue: https://github.com/utooland/utoo/issues/2269

先暂时把 `:global {}` 以及 `:global()` 中的伪元素场景忽略掉，这里先做最小改动，后续遇到了更多的 unsupported 伪类元素再看情况处理。