### PR TITLE
fix(turbopack): runtimePublic prefix deal

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/runtime-base.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/runtime-base.ts
@@ -377,9 +377,12 @@ function getPathFromScript(
       : chunkScript.getAttribute('src')!
   const src = decodeURIComponent(chunkUrl.replace(/[?#].*$/, ''))
   const runtimeBasePath = getRuntimeChunkBasePath()
-  const path = src.startsWith(runtimeBasePath)
+  let path = src.startsWith(runtimeBasePath)
     ? src.slice(runtimeBasePath.length)
     : src
+  if (path.startsWith('/')) {
+    path = path.slice(1)
+  }
   return path as ChunkPath | ChunkListPath
 }
 


### PR DESCRIPTION
处理当 runtimePublicPath 为 localhost 时的路径问题。