### PR TITLE
fix(turbopack): set tsconfig not extends as warning not error

### DIFF
--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -118,7 +118,7 @@ pub async fn read_tsconfigs(
                         continue;
                     } else {
                         TsConfigIssue {
-                            severity: IssueSeverity::Error,
+                            severity: IssueSeverity::Warning,
                             // TODO: this should point at the `extends` property
                             source: IssueSource::from_source_only(tsconfig),
                             message: format!("extends: \"{extends}\" doesn't resolve correctly")


### PR DESCRIPTION
修复: 

<img width="1425" height="253" alt="截屏2025-11-06 20 16 44" src="https://github.com/user-attachments/assets/ac5708d2-7e84-49e7-9b84-ce66d223b20c" />

把这个当作 warning 抛出来而不是 error。