### PR TITLE
fix(turbopack): downgrade duplicate binding from error to warn

### DIFF
--- a/turbopack/crates/turbopack-swc-utils/src/emitter.rs
+++ b/turbopack/crates/turbopack-swc-utils/src/emitter.rs
@@ -123,14 +123,29 @@ impl Emitter for IssueEmitter {
         let severity = if is_lint {
             IssueSeverity::Suggestion
         } else {
+            // Check if this is a duplicate binding error and downgrade to warning
+            let is_duplicate_binding_error = message.contains("defined multiple times");
+
             match level {
                 Level::Bug => IssueSeverity::Bug,
                 Level::Fatal | Level::PhaseFatal => IssueSeverity::Fatal,
-                Level::Error => IssueSeverity::Error,
+                Level::Error => {
+                    if is_duplicate_binding_error {
+                        IssueSeverity::Warning
+                    } else {
+                        IssueSeverity::Error
+                    }
+                }
                 Level::Warning => IssueSeverity::Warning,
                 Level::Note => IssueSeverity::Note,
                 Level::Help => IssueSeverity::Hint,
-                Level::Cancelled => IssueSeverity::Error,
+                Level::Cancelled => {
+                    if is_duplicate_binding_error {
+                        IssueSeverity::Warning
+                    } else {
+                        IssueSeverity::Error
+                    }
+                }
                 Level::FailureNote => IssueSeverity::Note,
             }
         };


### PR DESCRIPTION
https://github.com/swc-project/swc/blob/main/crates/swc_ecma_lints/src/rules/critical_rules.rs#L770 

把这个 error 先放宽成 warn，webpack 对这种 case 不会检查。