### PR TITLE
fix(turbopack): remove loader require.resolve paths params

### DIFF
--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -1,5 +1,5 @@
 declare const __turbopack_external_require__: {
-  resolve: (name: string, opt: { paths: string[] }) => string
+  resolve: (name: string, opt?: { paths: string[] }) => string
 } & ((id: string, thunk: () => any, esm?: boolean) => any)
 
 import type { Ipc } from '../ipc/evaluate'
@@ -462,7 +462,7 @@ const transform = (
         },
 
         loaders: loadersWithOptions.map((loader) => ({
-          loader: __turbopack_external_require__.resolve(loader.loader, {}),
+          loader: __turbopack_external_require__.resolve(loader.loader),
           options: loader.options,
         })),
         readResource: (_filename, callback) => {

--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -156,7 +156,6 @@ const transform = (
 ) => {
   return new Promise((resolve, reject) => {
     const resource = pathResolve(contextDir, name)
-    const resourceDir = dirname(resource)
 
     const loadersWithOptions = loaders.map((loader) =>
       typeof loader === 'string' ? { loader, options: {} } : loader
@@ -463,9 +462,7 @@ const transform = (
         },
 
         loaders: loadersWithOptions.map((loader) => ({
-          loader: __turbopack_external_require__.resolve(loader.loader, {
-            paths: [contextDir, resourceDir],
-          }),
+          loader: __turbopack_external_require__.resolve(loader.loader, {}),
           options: loader.options,
         })),
         readResource: (_filename, callback) => {


### PR DESCRIPTION
适配 PR: https://github.com/utooland/utoo/pull/2299

因为 `.turbopack` 被移到 `@utoo/pack` 下面去了，loader 应该从 `@utoo/pack` 那层开始找，而不是从项目的 cwd 找。

本地测试:

<img width="1151" height="296" alt="截屏2025-11-10 16 08 59" src="https://github.com/user-attachments/assets/06f40bc5-004b-454a-a4a8-9f3e2c03b456" />

