### PR TITLE
fix(turbopack): support parse `~` prefix for less & sass

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -162,6 +162,20 @@ impl Request {
             return Request::Empty;
         }
 
+        // Handle webpack-style tilde prefix (~) for node_modules resolution
+        // This is commonly used in CSS preprocessors like less-loader and sass-loader
+        // Only strip ~ if it's followed by a module path (not a relative path like ~/home)
+        // for utoopack issue: https://github.com/utooland/utoo/issues/2309
+        let r = if let Some(remainder) = r
+            .strip_prefix('~')
+            .filter(|s| !s.is_empty() && !s.starts_with('/') && !s.starts_with('\\'))
+            .filter(|s| MODULE_PATH.is_match(s))
+        {
+            remainder.into()
+        } else {
+            r
+        };
+
         if let Some(remainder) = r.strip_prefix("//") {
             return Request::Uri {
                 protocol: rcstr!("//"),


### PR DESCRIPTION
让 resolve 去把 `~${moduleName}/xx.css` 先直接处理成 `${moduleName}/xx.css`。

for issue: https://github.com/utooland/utoo/issues/2309