### PR TITLE
fix(turbopack): ignore non-js module chunk when resolve

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -29,6 +29,7 @@ use turbopack_core::{
 
 use super::util::{request_to_string, throw_module_not_found_expr};
 use crate::{
+    chunk::EcmascriptChunkPlaceable,
     references::util::throw_module_not_found_error_expr,
     runtime_functions::{
         TURBOPACK_ASYNC_LOADER, TURBOPACK_EXTERNAL_IMPORT, TURBOPACK_EXTERNAL_REQUIRE,
@@ -361,6 +362,13 @@ async fn to_single_pattern_mapping(
         }
     };
     if let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module) {
+        // Check if it's an EcmascriptChunkPlaceable
+        // Non-JS modules should be ignored as their side effects
+        // are handled through their own chunk types
+        if ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module).is_none() {
+            return Ok(SinglePatternMapping::Ignored);
+        }
+
         match resolve_type {
             ResolveType::AsyncChunkLoader => {
                 let loader_id = chunking_context.async_loader_chunk_item_id(*chunkable);


### PR DESCRIPTION
在 resolve 阶段把非 JS Chunkable 的 request 给 ignore 掉，这里处理方式和处理 externals 的 empty 方式类似。

这里改动应该只会影响到 CssModuleAsset (全局 CSS 文件)。

issue: https://github.com/utooland/utoo/issues/2375