### PR TITLE
fix(turbopack): define object too big to make effect

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1381,15 +1381,23 @@ async fn analyze_ecmascript_module_internal(
                     }
 
                     // FreeVar("require") might be turbopackIgnore-d
-                    if !analysis_state
+                    let linked_value = analysis_state
                         .link_value(
                             JsValue::FreeVar(var.clone()),
                             eval_context.imports.get_attributes(span),
                         )
-                        .await?
-                        .is_unknown()
-                    {
-                        // Call handle free var
+                        .await?;
+                    
+                    // Call handle_free_var if the value is not unknown, or if it might be in free_var_references
+                    // (e.g., when Object is too large and gets converted to Unknown in link_value, but we still
+                    // need to add code generation via ConstantValueCodeGen)
+                    if !linked_value.is_unknown() || {
+                        let free_var_js = JsValue::FreeVar(var.clone());
+                        free_var_js.get_definable_name_len()
+                            .and_then(|_| free_var_js.iter_definable_name_rev().next())
+                            .and_then(|first| analysis_state.free_var_references.get(&*first))
+                            .is_some()
+                    } {
                         handle_free_var(
                             &ast_path,
                             JsValue::FreeVar(var),
@@ -4076,3 +4084,4 @@ fn is_invoking_node_process_eval(args: &[JsValue]) -> bool {
 
     false
 }
+

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1393,8 +1393,8 @@ async fn analyze_ecmascript_module_internal(
                     // need to add code generation via ConstantValueCodeGen)
                     if !linked_value.is_unknown() || {
                         let free_var_js = JsValue::FreeVar(var.clone());
-                        free_var_js.get_definable_name_len()
-                            .and_then(|_| free_var_js.iter_definable_name_rev().next())
+                        free_var_js.iter_definable_name_rev()
+                            .next()
                             .and_then(|first| analysis_state.free_var_references.get(&*first))
                             .is_some()
                     } {


### PR DESCRIPTION
object 太大导致 link_value 超出了 LIMIT_NODE_SIZE，导致 link_value 被处理成了 JsValue::Unknown 类型。

从而没触发 handle_free_var 的变量替换逻辑。

Related issue: https://github.com/utooland/utoo/issues/2388