### PR TITLE
perf(turbo-tasks-malloc): use forked mimalloc on wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3675,6 +3675,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "git+https://github.com/utooland/mimalloc_rust.git#fed2a960edab4e74dcffda3be0bb32cf46085c79"
+dependencies = [
+ "cc",
+ "cty",
+ "libc",
+]
+
+[[package]]
 name = "libunwind"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,12 +4040,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "mimalloc-rspack"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de20bb33bf95d9c060030d53bcb5d5dc03cbbedfbd1dcda5f6f285b946dae2c0"
+name = "mimalloc"
+version = "0.1.48"
+source = "git+https://github.com/utooland/mimalloc_rust.git#fed2a960edab4e74dcffda3be0bb32cf46085c79"
 dependencies = [
- "rspack-libmimalloc-sys",
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -6056,17 +6065,6 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "serde",
-]
-
-[[package]]
-name = "rspack-libmimalloc-sys"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c741844b1fbe0cfbae8dfeb73b5e5fdc95daf7be58bdd72afb3fd85c86bccdb"
-dependencies = [
- "cc",
- "cty",
- "libc",
 ]
 
 [[package]]
@@ -9483,8 +9481,7 @@ dependencies = [
 name = "turbo-tasks-malloc"
 version = "0.1.0"
 dependencies = [
- "mimalloc-rspack",
- "rspack-libmimalloc-sys",
+ "mimalloc",
 ]
 
 [[package]]

--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -9,22 +9,19 @@ autobenches = false
 [lib]
 bench = false
 
-[dependencies]
-rspack-libmimalloc-sys = { version = "0.2.4", default-features = false, features = [], optional = true }
-
-[target.'cfg(not(any(target_os = "linux", target_family = "wasm", target_env = "musl")))'.dependencies]
-mimalloc-rspack = { version = "0.2.4", features = [
+[target.'cfg(not(any(target_os = "linux",  target_env = "musl")))'.dependencies]
+mimalloc = {  git = "https://github.com/utooland/mimalloc_rust.git", features = [
   "v3",
   "extended"
 ], optional = true }
 
-[target.'cfg(all(target_os = "linux", not(any(target_family = "wasm", target_env = "musl"))))'.dependencies]
-mimalloc-rspack = { version = "0.2.4", features = [
+[target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
+mimalloc = { git = "https://github.com/utooland/mimalloc_rust.git", features = [
   "v3",
   "extended",
   "local_dynamic_tls",
 ], optional = true }
 
 [features]
-custom_allocator = ["dep:mimalloc-rspack", "dep:rspack-libmimalloc-sys"]
+custom_allocator = ["dep:mimalloc"]
 default = ["custom_allocator"]

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -114,29 +114,17 @@ impl TurboMalloc {
 /// Get the allocator for this platform that we should wrap with TurboMalloc.
 #[inline]
 fn base_alloc() -> &'static impl GlobalAlloc {
-    #[cfg(all(
-        feature = "custom_allocator",
-        not(any(target_family = "wasm", target_env = "musl"))
-    ))]
-    return &mimalloc_rspack::MiMalloc;
-    #[cfg(any(
-        not(feature = "custom_allocator"),
-        any(target_family = "wasm", target_env = "musl")
-    ))]
+    #[cfg(all(feature = "custom_allocator", not(target_env = "musl")))]
+    return &mimalloc::MiMalloc;
+    #[cfg(any(not(feature = "custom_allocator"), target_env = "musl"))]
     return &std::alloc::System;
 }
 
 #[allow(unused_variables)]
 unsafe fn base_alloc_size(ptr: *const u8, layout: Layout) -> usize {
-    #[cfg(all(
-        feature = "custom_allocator",
-        not(any(target_family = "wasm", target_env = "musl"))
-    ))]
-    return unsafe { mimalloc_rspack::MiMalloc.usable_size(ptr) };
-    #[cfg(any(
-        not(feature = "custom_allocator"),
-        any(target_family = "wasm", target_env = "musl")
-    ))]
+    #[cfg(all(feature = "custom_allocator", not(target_env = "musl")))]
+    return unsafe { mimalloc::MiMalloc.usable_size(ptr) };
+    #[cfg(any(not(feature = "custom_allocator"), target_env = "musl"))]
     return layout.size();
 }
 


### PR DESCRIPTION
https://github.com/utooland/mimalloc/commit/88e710e
https://github.com/utooland/mimalloc_rust/commit/fed2a96

It improves performance by `100%`

`dlmalloc`
<img width="838" height="183" alt="image" src="https://github.com/user-attachments/assets/08cf6cf5-6d11-4fb8-8d1c-cd83404b872d" />

`mimalloc`
<img width="709" height="172" alt="image" src="https://github.com/user-attachments/assets/aedad9f2-a6da-4946-8303-fe6a260f4a37" />
