### PR TITLE
fix(turbopack): use var to replace const at esm export codegen

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
@@ -46,7 +46,7 @@ impl EsmModuleItem {
                 if let ModuleItem::ModuleDecl(module_decl) = item {
                     match module_decl {
                         ModuleDecl::ExportDefaultExpr(ExportDefaultExpr { box expr, .. }) => {
-                            let stmt = quote!("const $name = $expr;" as Stmt,
+                            let stmt = quote!("var $name = $expr;" as Stmt,
                                 name = Ident::new(magic_identifier::mangle("default export").into(), DUMMY_SP, Default::default()),
                                 expr: Expr = expr
                             );

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -1117,7 +1117,7 @@ impl DepGraph {
                                 content: ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(
                                     VarDecl {
                                         span: DUMMY_SP,
-                                        kind: VarDeclKind::Const,
+                                        kind: VarDeclKind::Var,
                                         decls: vec![VarDeclarator {
                                             span: DUMMY_SP,
                                             name: default_var.clone().into(),


### PR DESCRIPTION
主要为了修复: https://github.com/utooland/utoo/issues/2385

有个循环依赖的例子:

```ts
// a.ts
import c from './c';

export default c;
```

```ts
// c.ts
import a from './a';

a;

const c = 1;
export default c;
```

在 codegen 的时候 turbopack 会把 a module 里面的 c module 的导出给提上来，看上去是为了避免 import 消费的模块能找到对应的变量。

<img width="2940" height="526" alt="image" src="https://github.com/user-attachments/assets/9df2f630-f9bc-490f-916e-f0b3fedcbe37" />

参考代码逻辑: https://github.com/utooland/next.js/blob/utoo/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs#L825

于是就会构造出 issue 中的报错，这里简单的解决办法就是把 const 替换成 var，让变量同样提升上去。

本地测试正常。
