### PR TITLE
fix(turbopack-core): fs root output name

### DIFF
--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -434,10 +434,10 @@ impl ValueToString for AssetIdent {
 }
 
 fn clean_separators(s: &str) -> String {
-    static SEPARATOR_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"[/#?]").unwrap());
+    static SEPARATOR_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"[/#?\[\]<>]").unwrap());
     SEPARATOR_REGEX.replace_all(s, "_").to_string()
 }
 
 fn clean_additional_extensions(s: &str) -> String {
-    s.replace('.', "_").replace("[root-of-the-server]", "")
+    s.replace('.', "_")
 }


### PR DESCRIPTION
Repalce undesirable characters like `[`, `]`, `<`, `>` with `_`.