### PR TITLE
fix(turbopack-node): incorrect idle_workers stats

### DIFF
--- a/turbopack/crates/turbopack-node/src/pool_stats.rs
+++ b/turbopack/crates/turbopack-node/src/pool_stats.rs
@@ -44,11 +44,11 @@ impl NodeJsPoolStats {
     }
 
     pub fn finished_booting_worker(&mut self) {
-        self.booting_workers -= 1;
+        self.booting_workers = self.booting_workers.saturating_sub(1);
     }
 
     pub fn remove_worker(&mut self) {
-        self.workers -= 1;
+        self.workers = self.workers.saturating_sub(1);
     }
 
     #[allow(unused)]
@@ -60,14 +60,14 @@ impl NodeJsPoolStats {
     pub fn add_cold_process_time(&mut self, time: Duration) {
         self.total_cold_process_time += time;
         self.cold_process_count += 1;
-        self.queued_tasks -= 1;
+        self.queued_tasks = self.queued_tasks.saturating_sub(1);
     }
 
     #[allow(unused)]
     pub fn add_warm_process_time(&mut self, time: Duration) {
         self.total_warm_process_time += time;
         self.warm_process_count += 1;
-        self.queued_tasks -= 1;
+        self.queued_tasks = self.queued_tasks.saturating_sub(1);
     }
 
     pub fn estimated_bootup_time(&self) -> Duration {

--- a/turbopack/crates/turbopack-node/src/worker_pool/worker_thread.rs
+++ b/turbopack/crates/turbopack-node/src/worker_pool/worker_thread.rs
@@ -22,8 +22,7 @@ static WORKER_TERMINATOR: OnceCell<
     ThreadsafeFunction<NapiWorkerTermination, ErrorStrategy::Fatal>,
 > = OnceCell::new();
 
-static PENDING_CREATIONS: OnceCell<Mutex<VecDeque<(Arc<WorkerOptions>, oneshot::Sender<u32>)>>> =
-    OnceCell::new();
+static PENDING_CREATIONS: OnceCell<Mutex<VecDeque<oneshot::Sender<u32>>>> = OnceCell::new();
 
 #[napi]
 #[allow(unused)]
@@ -58,6 +57,8 @@ pub fn register_worker_scheduler(
 pub async fn create_worker(options: Arc<WorkerOptions>) -> anyhow::Result<u32> {
     let (tx, rx) = oneshot::channel();
 
+    let napi_options = (&options).into();
+
     {
         let pending = PENDING_CREATIONS.get_or_init(|| Mutex::new(VecDeque::new()));
         // ensure pool entry exists for these options so scale ops can observe it
@@ -66,13 +67,13 @@ pub async fn create_worker(options: Arc<WorkerOptions>) -> anyhow::Result<u32> {
             .lock()
             .entry(options.clone())
             .or_default();
-        pending.lock().push_back((options.clone(), tx));
+        pending.lock().push_back(tx);
     }
 
     if let Some(creator) = WORKER_CREATOR.get() {
         creator.call(
             NapiWorkerCreation {
-                options: options.into(),
+                options: napi_options,
             },
             ThreadsafeFunctionCallMode::NonBlocking,
         );
@@ -87,19 +88,10 @@ pub async fn create_worker(options: Arc<WorkerOptions>) -> anyhow::Result<u32> {
 #[napi]
 #[allow(unused)]
 pub fn worker_created(worker_id: u32) {
-    if let Some(pending) = PENDING_CREATIONS.get() {
-        if let Some((options, tx)) = pending.lock().pop_front() {
-            // record into global pool
-            WORKER_POOL_OPERATION
-                .pools
-                .lock()
-                .entry(options.clone())
-                .or_default()
-                .idle_workers
-                .lock()
-                .push(worker_id);
-            let _ = tx.send(worker_id);
-        }
+    if let Some(pending) = PENDING_CREATIONS.get()
+        && let Some(tx) = pending.lock().pop_front()
+    {
+        let _ = tx.send(worker_id);
     }
 }
 


### PR DESCRIPTION
This pull request refactors the worker creation and tracking logic in the Node.js pool, with a focus on simplifying how pending worker creations are managed and improving the robustness of worker statistics updates. The main changes are grouped into two themes: improvements to statistics handling and simplification of the worker creation queue.

**Improvements to statistics handling:**

* Replaced direct subtraction with `saturating_sub` in the `NodeJsPoolStats` methods to prevent underflow when decrementing counters such as `booting_workers`, `workers`, and `queued_tasks`. [[1]](diffhunk://#diff-b18045b5c642843d2540fab287e60229f3d93da86aa90a8a2a5e715f30b1ec1dL47-R51) [[2]](diffhunk://#diff-b18045b5c642843d2540fab287e60229f3d93da86aa90a8a2a5e715f30b1ec1dL63-R70)

**Simplification of the worker creation queue:**

* Refactored `PENDING_CREATIONS` to store only the `oneshot::Sender<u32>` instead of a tuple with `WorkerOptions`, reducing unnecessary data storage.
* Updated the logic in `create_worker` and `worker_created` to match the new structure of `PENDING_CREATIONS`, simplifying the push and pop operations and removing redundant code related to `WorkerOptions`. [[1]](diffhunk://#diff-741bca8f686e275d1be0951520f7fc6e0c36d982902889c1b892c35516151263L69-R76) [[2]](diffhunk://#diff-741bca8f686e275d1be0951520f7fc6e0c36d982902889c1b892c35516151263L90-L104)
* Added a conversion of `WorkerOptions` to `napi_options` early in `create_worker` for cleaner code and more explicit handling of options.