### PR TITLE
fix(turbopack): add `@` to clean_separators to avoid url decode

### DIFF
--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -945,7 +945,7 @@ struct ChunkPathInfo {
 }
 
 pub fn clean_separators(s: &str) -> String {
-    static SEPARATOR_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r".*[/#?]").unwrap());
+    static SEPARATOR_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[/#?@]").unwrap());
     SEPARATOR_REGEX.replace_all(s, "").to_string()
 }
 

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -434,7 +434,7 @@ impl ValueToString for AssetIdent {
 }
 
 fn clean_separators(s: &str) -> String {
-    static SEPARATOR_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"[/#?\[\]<>]").unwrap());
+    static SEPARATOR_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"[/#?\[\]<>@]").unwrap());
     SEPARATOR_REGEX.replace_all(s, "_").to_string()
 }
 


### PR DESCRIPTION
Before:

<img width="750" height="50" alt="image" src="https://github.com/user-attachments/assets/384dceb9-09f3-4d67-b9cf-f5a9d2df0b5e" />

After:

<img width="1444" height="196" alt="image" src="https://github.com/user-attachments/assets/e006721e-7104-4c92-b648-423353c43c7f" />
