### PR TITLE
chore: remove dumplicate clean_separators

### DIFF
--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -944,11 +944,6 @@ struct ChunkPathInfo {
     content_hashing: Option<ContentHashing>,
 }
 
-pub fn clean_separators(s: &str) -> String {
-    static SEPARATOR_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[/#?@]").unwrap());
-    SEPARATOR_REGEX.replace_all(s, "").to_string()
-}
-
 static NAME_PLACEHOLDER_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\[name\]").unwrap());
 
 pub fn match_name_placeholder(s: &str) -> bool {

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -433,7 +433,7 @@ impl ValueToString for AssetIdent {
     }
 }
 
-fn clean_separators(s: &str) -> String {
+pub fn clean_separators(s: &str) -> String {
     static SEPARATOR_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"[/#?\[\]<>@]").unwrap());
     SEPARATOR_REGEX.replace_all(s, "_").to_string()
 }


### PR DESCRIPTION
清理重复的 `clean_separators` 方法，目前 turbopack 里面没地方消费 turbopack-browser 里面的这个方法