### PR TITLE
perf(turbo-tasks): avoid full mem move in tokio runtime

### DIFF
--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -855,6 +855,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
             .instrument(span)
             .await
         };
+        let future = Box::pin(future);
         let future = global_task_state
             .read()
             .unwrap()


### PR DESCRIPTION
Avoid mem move of `turbo-tasks`, improve by `3%`
<img width="1301" height="529" alt="image" src="https://github.com/user-attachments/assets/37b1b2ed-d13e-4169-bb94-b09033ecab0c" />

- Before
<img width="973" height="210" alt="image" src="https://github.com/user-attachments/assets/b45bc5a4-75fa-448d-be0f-8bc4692f9331" />

- After
<img width="973" height="197" alt="image" src="https://github.com/user-attachments/assets/a07a5815-e013-4191-83a4-1d321aaefb92" />
