### PR TITLE
fix: use threadId from worker_threads instead of workerId from workerData

### DIFF
--- a/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
@@ -5,6 +5,7 @@ declare const __turbopack_external_require__: (
 ) => any
 
 import type { Processor } from 'postcss'
+import { workerData } from 'worker_threads'
 
 // @ts-ignore
 import postcss from '@vercel/turbopack/postcss'
@@ -133,8 +134,7 @@ export default async function transform(
   }
 }
 
-// @ts-ignore
-if (typeof self !== 'undefined' && self.workerData && self.workerData.binding) {
+if (workerData && workerData.binding) {
   // @ts-ignore
   const { run } = require('../web_worker/evaluate')
   run(async () => {

--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -17,6 +17,7 @@ import {
 } from './transforms'
 import fs from 'fs'
 import path from 'path'
+import { workerData } from 'worker_threads'
 
 export type IpcInfoMessage =
   | {
@@ -509,8 +510,7 @@ const transform = (
 
 export { transform as default }
 
-// @ts-ignore
-if (typeof self !== 'undefined' && self.workerData && self.workerData.binding) {
+if (workerData && workerData.binding) {
   // @ts-ignore
   const { run } = require('../web_worker/evaluate')
   run(async () => {

--- a/turbopack/crates/turbopack-node/js/src/web_worker/evaluate.ts
+++ b/turbopack/crates/turbopack-node/js/src/web_worker/evaluate.ts
@@ -6,20 +6,13 @@ import {
 } from '../worker_thread/taskChannel'
 import { structuredError } from '../error'
 import type { Channel } from '../types'
+import { workerData, threadId as workerId } from 'worker_threads'
 
-export type Self = DedicatedWorkerGlobalScope & {
-  workerData: {
-    workerId: number
-    cwd: string
-    binding: Binding
-  }
-}
+export type Self = DedicatedWorkerGlobalScope
 
 export declare const self: Self
-// @ts-ignore
-const { workerId } = self.workerData
 
-let binding: Binding = self.workerData.binding
+let binding: Binding = workerData.binding
 
 binding.workerCreated(workerId)
 


### PR DESCRIPTION
This pull request updates how worker thread data is accessed in the Turbopack codebase. The main change is to consistently use Node.js's `worker_threads.workerData` and `worker_threads.threadId` APIs instead of relying on a custom `self.workerData` object. This improves reliability and aligns the code with standard Node.js worker thread practices.

**Worker thread data handling updates:**

* Replaced usage of `self.workerData` with direct imports from `worker_threads` (`workerData`, `threadId`) in `postcss.ts`, `webpack-loaders.ts`, and `evaluate.ts` to standardize worker data access and remove custom global augmentation. [[1]](diffhunk://#diff-d118a165924292b07fdcfaea00665ddeab821dd8991a7881bbc4f2e5bf7cbb90R8) [[2]](diffhunk://#diff-2680f20c4e8aa0fd69e95291608f2adf7fad0d980123778434f9ce9a2014b74fR20) [[3]](diffhunk://#diff-f90b33b83d05010f03beccf745f9959cd5c3abfc10d02a62088ad3ed2c397609R9-R15)

* Updated worker entrypoint checks in both `postcss.ts` and `webpack-loaders.ts` to use `workerData` instead of `self.workerData` for determining if the worker should run, simplifying the worker initialization logic. [[1]](diffhunk://#diff-d118a165924292b07fdcfaea00665ddeab821dd8991a7881bbc4f2e5bf7cbb90L136-R137) [[2]](diffhunk://#diff-2680f20c4e8aa0fd69e95291608f2adf7fad0d980123778434f9ce9a2014b74fL512-R513)

* Refactored the `Self` type in `evaluate.ts` to remove the `workerData` property, since all worker data is now accessed via the `worker_threads` module.