### PR TITLE
feat(turbopack): optimize resolve plugin conditions with Option

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1685,9 +1685,11 @@ async fn handle_before_resolve_plugins(
     options: Vc<ResolveOptions>,
 ) -> Result<Option<Vc<ResolveResult>>> {
     for plugin in &options.await?.before_resolve_plugins {
-        let condition = plugin.before_resolve_condition().resolve().await?;
-        if !*condition.matches(request).await? {
-            continue;
+        let condition_option = plugin.before_resolve_condition().await?;
+        if let Some(condition) = *condition_option {
+            if !*condition.matches(request).await? {
+                continue;
+            }
         }
 
         if let Some(result) = *plugin
@@ -1716,17 +1718,30 @@ async fn handle_after_resolve_plugins(
         options: Vc<ResolveOptions>,
     ) -> Result<Option<Vc<ResolveResult>>> {
         for plugin in &options.await?.after_resolve_plugins {
-            let after_resolve_condition = plugin.after_resolve_condition().resolve().await?;
-            if *after_resolve_condition.matches(path.clone()).await?
-                && let Some(result) = *plugin
-                    .after_resolve(
-                        path.clone(),
-                        lookup_path.clone(),
-                        reference_type.clone(),
-                        request,
-                    )
-                    .await?
+            let after_resolve_condition_option = plugin.after_resolve_condition().await?;
+            if let Some(condition) = *after_resolve_condition_option {
+                if *condition.matches(path.clone()).await?
+                    && let Some(result) = *plugin
+                        .after_resolve(
+                            path.clone(),
+                            lookup_path.clone(),
+                            reference_type.clone(),
+                            request,
+                        )
+                        .await?
+                {
+                    return Ok(Some(*result));
+                }
+            } else if let Some(result) = *plugin
+                .after_resolve(
+                    path.clone(),
+                    lookup_path.clone(),
+                    reference_type.clone(),
+                    request,
+                )
+                .await?
             {
+                // If there is no condition, the plugin applies to all paths.
                 return Ok(Some(*result));
             }
         }

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -40,6 +40,22 @@ impl AfterResolvePluginCondition {
     }
 }
 
+#[turbo_tasks::value(transparent)]
+pub struct OptionAfterResolvePluginCondition(Option<ResolvedVc<AfterResolvePluginCondition>>);
+
+#[turbo_tasks::value_impl]
+impl OptionAfterResolvePluginCondition {
+    #[turbo_tasks::function]
+    pub fn none() -> Vc<Self> {
+        Vc::cell(None)
+    }
+
+    #[turbo_tasks::function]
+    pub fn some(condition: ResolvedVc<AfterResolvePluginCondition>) -> Vc<Self> {
+        Vc::cell(Some(condition))
+    }
+}
+
 /// A condition which determines if the hooks of a resolve plugin gets called.
 #[turbo_tasks::value]
 pub enum BeforeResolvePluginCondition {
@@ -80,10 +96,26 @@ impl BeforeResolvePluginCondition {
     }
 }
 
+#[turbo_tasks::value(transparent)]
+pub struct OptionBeforeResolvePluginCondition(Option<ResolvedVc<BeforeResolvePluginCondition>>);
+
+#[turbo_tasks::value_impl]
+impl OptionBeforeResolvePluginCondition {
+    #[turbo_tasks::function]
+    pub fn none() -> Vc<Self> {
+        Vc::cell(None)
+    }
+
+    #[turbo_tasks::function]
+    pub fn some(condition: ResolvedVc<BeforeResolvePluginCondition>) -> Vc<Self> {
+        Vc::cell(Some(condition))
+    }
+}
+
 #[turbo_tasks::value_trait]
 pub trait BeforeResolvePlugin {
     #[turbo_tasks::function]
-    fn before_resolve_condition(self: Vc<Self>) -> Vc<BeforeResolvePluginCondition>;
+    fn before_resolve_condition(self: Vc<Self>) -> Vc<OptionBeforeResolvePluginCondition>;
 
     #[turbo_tasks::function]
     fn before_resolve(
@@ -98,7 +130,7 @@ pub trait BeforeResolvePlugin {
 pub trait AfterResolvePlugin {
     /// A condition which determines if the hooks gets called.
     #[turbo_tasks::function]
-    fn after_resolve_condition(self: Vc<Self>) -> Vc<AfterResolvePluginCondition>;
+    fn after_resolve_condition(self: Vc<Self>) -> Vc<OptionAfterResolvePluginCondition>;
 
     /// This hook gets called when a full filepath has been resolved and the
     /// condition matches. If a value is returned it replaces the resolve


### PR DESCRIPTION
This PR refactors the Resolution Plugin traits to use Option for their conditions. This allow plugins to return None, skipping the expensive matches task calls entirely. Testing on a medium project showed a reduction of resolve_call tasks.