### PR TITLE
feat(turbo-tasks-fs): support ignore option

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -634,7 +634,7 @@ impl DiskFileSystem {
     /// * `root` - Path to the given filesystem's root. Should be
     ///   [canonicalized][std::fs::canonicalize].
     pub fn new(name: RcStr, root: RcStr) -> Vc<Self> {
-        Self::new_internal(name, root, Vec::new())
+        Self::new_internal(name, root, Vec::new(), Vec::new())
     }
 
     /// Create a new instance of `DiskFileSystem`.
@@ -651,7 +651,7 @@ impl DiskFileSystem {
             normalize_path(&denied_path).as_deref() == Some(&*denied_path),
             "denied_path must be normalized: {denied_path:?}"
         );
-        Self::new_internal(name, root, vec![denied_path])
+        Self::new_internal(name, root, vec![denied_path], Vec::new())
     }
 
     pub fn new_with_denied_paths(name: RcStr, root: RcStr, denied_paths: Vec<RcStr>) -> Vc<Self> {
@@ -662,15 +662,50 @@ impl DiskFileSystem {
                 "denied_path must be normalized: {denied_path:?}"
             );
         }
-        Self::new_internal(name, root, denied_paths)
+        Self::new_internal(name, root, denied_paths, Vec::new())
+    }
+
+    /// Create a new instance of `DiskFileSystem` with watch ignore patterns.
+    /// # Arguments
+    ///
+    /// * `name` - Name of the filesystem.
+    /// * `root` - Path to the given filesystem's root. Should be
+    ///   [canonicalized][std::fs::canonicalize].
+    /// * `denied_paths` - Paths within this filesystem that are not allowed to be accessed.
+    /// * `watched_ignored` - Paths that should be ignored when watching for file changes.
+    pub fn new_with_watched_ignored(
+        name: RcStr,
+        root: RcStr,
+        denied_paths: Vec<RcStr>,
+        watched_ignored: Vec<RcStr>,
+    ) -> Vc<Self> {
+        for denied_path in &denied_paths {
+            debug_assert!(!denied_path.is_empty(), "denied_path must not be empty");
+            debug_assert!(
+                normalize_path(denied_path).as_deref() == Some(&**denied_path),
+                "denied_path must be normalized: {denied_path:?}"
+            );
+        }
+        Self::new_internal(name, root, denied_paths, watched_ignored)
     }
 }
 
 #[turbo_tasks::value_impl]
 impl DiskFileSystem {
     #[turbo_tasks::function]
-    fn new_internal(name: RcStr, root: RcStr, denied_paths: Vec<RcStr>) -> Vc<Self> {
+    fn new_internal(
+        name: RcStr,
+        root: RcStr,
+        denied_paths: Vec<RcStr>,
+        watched_ignored: Vec<RcStr>,
+    ) -> Vc<Self> {
         mark_stateful();
+
+        let watcher = if watched_ignored.is_empty() {
+            DiskWatcher::new()
+        } else {
+            DiskWatcher::new_with_ignored_paths(watched_ignored)
+        };
 
         let instance = DiskFileSystem {
             inner: Arc::new(DiskFileSystemInner {
@@ -682,7 +717,7 @@ impl DiskFileSystem {
                 dir_invalidator_map: InvalidatorMap::new(),
                 read_semaphore: create_read_semaphore(),
                 write_semaphore: create_write_semaphore(),
-                watcher: DiskWatcher::new(),
+                watcher,
                 denied_paths,
             }),
         };

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -66,6 +66,9 @@ static WATCH_RECURSIVE_MODE: LazyLock<RecursiveMode> = LazyLock::new(|| {
 pub(crate) struct DiskWatcher {
     #[bincode(skip)]
     state: State,
+    /// Paths to ignore when watching for file changes
+    #[bincode(skip)]
+    ignored_paths: Arc<Vec<RcStr>>,
 }
 
 enum State {
@@ -347,9 +350,29 @@ mod non_recursive_helpers {
 
 impl DiskWatcher {
     pub fn new() -> Self {
+        Self::new_with_ignored_paths(vec!["node_modules".into()])
+    }
+
+    pub fn new_with_ignored_paths(ignored_paths: Vec<RcStr>) -> Self {
         Self {
             state: State::new_stopped(),
+            ignored_paths: Arc::new(ignored_paths),
         }
+    }
+
+    /// Check if a path should be ignored based on configured ignore patterns
+    fn should_ignore_path(&self, path: &Path) -> bool {
+        path.components().any(|component| {
+            if let std::path::Component::Normal(name) = component {
+                if let Some(name_str) = name.to_str() {
+                    return self.ignored_paths.iter().any(|ignored| {
+                        // Exact match or pattern match
+                        name_str == ignored.as_str()
+                    });
+                }
+            }
+            false
+        })
     }
 
     /// Create a watcher and start watching by creating `debounced` watcher
@@ -674,7 +697,11 @@ impl DiskWatcher {
                             break;
                         }
 
-                        let paths: Vec<PathBuf> = event.paths;
+                        let paths: Vec<PathBuf> = event
+                            .paths
+                            .into_iter()
+                            .filter(|path| !self.should_ignore_path(path))
+                            .collect();
                         if paths.is_empty() {
                             // this event isn't useful, but keep trying to process the batch
                             event_result = rx.try_recv();

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -368,7 +368,10 @@ impl DiskWatcher {
         path.components().any(|component| {
             if let Component::Normal(name) = component {
                 if let Some(name_str) = name.to_str() {
-                    return self.ignored_paths.contains(name_str);
+                    return self
+                        .ignored_paths
+                        .iter()
+                        .any(|ignored| ignored.as_str() == name_str);
                 }
             }
             false
@@ -504,9 +507,29 @@ impl DiskWatcher {
         use crate::wasm_fs_offload;
 
         let fs_inner_arc = fs_inner.clone();
+        let ignored_paths = self.ignored_paths.clone();
         let watch_dir = wasm_fs_offload::CLIENT
             .watch_dir(fs_inner.root_path(), true, move |event| {
-                let paths: Vec<PathBuf> = event.paths;
+                let paths: Vec<PathBuf> = if ignored_paths.is_empty() {
+                    event.paths
+                } else {
+                    event
+                        .paths
+                        .into_iter()
+                        .filter(|path| {
+                            !path.components().any(|component| {
+                                if let Component::Normal(name) = component {
+                                    if let Some(name_str) = name.to_str() {
+                                        return ignored_paths
+                                            .iter()
+                                            .any(|ignored| ignored.as_str() == name_str);
+                                    }
+                                }
+                                false
+                            })
+                        })
+                        .collect()
+                };
 
                 if paths.is_empty() {
                     return;

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -3,7 +3,7 @@ use std::{
     collections::BTreeSet,
     env, fmt,
     mem::take,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     sync::{
         Arc, LazyLock, RwLock, RwLockWriteGuard,
         mpsc::{Receiver, TryRecvError, channel},
@@ -362,13 +362,13 @@ impl DiskWatcher {
 
     /// Check if a path should be ignored based on configured ignore patterns
     fn should_ignore_path(&self, path: &Path) -> bool {
+        if self.ignored_paths.is_empty() {
+            return false;
+        }
         path.components().any(|component| {
-            if let std::path::Component::Normal(name) = component {
+            if let Component::Normal(name) = component {
                 if let Some(name_str) = name.to_str() {
-                    return self.ignored_paths.iter().any(|ignored| {
-                        // Exact match or pattern match
-                        name_str == ignored.as_str()
-                    });
+                    return self.ignored_paths.contains(name_str);
                 }
             }
             false

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -1,9 +1,9 @@
 use std::{cmp::min, sync::LazyLock};
 
 use anyhow::{Context, Result, bail};
+use bincode::{Decode, Encode};
 use qstring::QString;
 use regex::Regex;
-use bincode::{Decode, Encode};
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -28,12 +28,15 @@ use turbopack_core::{
 };
 
 use crate::{
-    chunk::EcmascriptChunkPlaceable, references::util::{
+    chunk::EcmascriptChunkPlaceable,
+    references::util::{
         request_to_string, throw_module_not_found_error_expr, throw_module_not_found_expr,
-    }, runtime_functions::{
+    },
+    runtime_functions::{
         TURBOPACK_ASYNC_LOADER, TURBOPACK_EXTERNAL_IMPORT, TURBOPACK_EXTERNAL_REQUIRE,
         TURBOPACK_IMPORT, TURBOPACK_MODULE_CONTEXT, TURBOPACK_REQUIRE,
-    }, utils::module_id_to_lit
+    },
+    utils::module_id_to_lit,
 };
 
 #[derive(PartialEq, Eq, ValueDebugFormat, TraceRawVcs, NonLocalValue, Encode, Decode)]

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -180,39 +180,39 @@ impl MdxTransformedAsset {
 
             let result = compile(&file.content().to_str()?, &options);
 
-        match result {
-            Ok(mdx_jsx_component) => Ok(MdxTransformResult {
-                content: AssetContent::file(
-                    FileContent::Content(File::from(Rope::from(mdx_jsx_component))).cell(),
-                )
-                .to_resolved()
-                .await?,
-            }
-            .cell()),
-            Err(err) => {
-                let source = match err.place {
-                    Some(p) => {
-                        let (start, end) = match *p {
-                            // markdown's positions are 1-indexed, SourcePos is 0-indexed.
-                            // Both end positions point to the first character after the range
-                            markdown::message::Place::Position(p) => (
-                                SourcePos {
-                                    line: (p.start.line - 1) as u32,
-                                    column: (p.start.column - 1) as u32,
-                                },
-                                SourcePos {
-                                    line: (p.end.line - 1) as u32,
-                                    column: (p.end.column - 1) as u32,
-                                },
-                            ),
-                            markdown::message::Place::Point(p) => {
-                                let p = SourcePos {
-                                    line: (p.line - 1) as u32,
-                                    column: (p.column - 1) as u32,
-                                };
-                                (p, p)
-                            }
-                        };
+            match result {
+                Ok(mdx_jsx_component) => Ok(MdxTransformResult {
+                    content: AssetContent::file(
+                        FileContent::Content(File::from(Rope::from(mdx_jsx_component))).cell(),
+                    )
+                    .to_resolved()
+                    .await?,
+                }
+                .cell()),
+                Err(err) => {
+                    let source = match err.place {
+                        Some(p) => {
+                            let (start, end) = match *p {
+                                // markdown's positions are 1-indexed, SourcePos is 0-indexed.
+                                // Both end positions point to the first character after the range
+                                markdown::message::Place::Position(p) => (
+                                    SourcePos {
+                                        line: (p.start.line - 1) as u32,
+                                        column: (p.start.column - 1) as u32,
+                                    },
+                                    SourcePos {
+                                        line: (p.end.line - 1) as u32,
+                                        column: (p.end.column - 1) as u32,
+                                    },
+                                ),
+                                markdown::message::Place::Point(p) => {
+                                    let p = SourcePos {
+                                        line: (p.line - 1) as u32,
+                                        column: (p.column - 1) as u32,
+                                    };
+                                    (p, p)
+                                }
+                            };
 
                             IssueSource::from_line_col(self.source, start, end)
                         }


### PR DESCRIPTION
turbopack 的 watch 新增一个 ignore 配置，用于忽略对一些文件的监听，比如 `node_modules`。