### PR TITLE
feat(turbopack): sort for module factory ident under chunk generate

### DIFF
--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -546,6 +546,8 @@ impl ChunkingContext for BrowserChunkingContext {
             content_hashing: _,
         } = &*self.chunk_path_info().await?;
 
+        // Await ident once and reuse it
+        let ident_ref = ident.await?;
         let output_name = ident
             .output_name(root_path.clone(), prefix, extension.clone())
             .owned()
@@ -553,11 +555,9 @@ impl ChunkingContext for BrowserChunkingContext {
 
         let mut filename = match asset {
             Some(asset) => {
-                let ident = ident.await?;
-
                 let mut evaluate = false;
                 let mut dev_chunk_list = false;
-                ident.modifiers.iter().for_each(|m| {
+                ident_ref.modifiers.iter().for_each(|m| {
                     if m.contains("evaluate") {
                         evaluate = true;
                     }
@@ -565,7 +565,7 @@ impl ChunkingContext for BrowserChunkingContext {
                         dev_chunk_list = true;
                     }
                 });
-                let query = QString::from(ident.query.as_str());
+                let query = QString::from(ident_ref.query.as_str());
                 let name = if dev_chunk_list {
                     output_name.as_str()
                 } else {
@@ -579,8 +579,8 @@ impl ChunkingContext for BrowserChunkingContext {
                 };
 
                 match filename_template {
-                    Some(filename) => {
-                        let mut filename = filename.to_string();
+                    Some(filename_template_str) => {
+                        let mut filename = filename_template_str.to_string();
 
                         if match_name_placeholder(&filename) {
                             filename = replace_name_placeholder(&filename, name);
@@ -590,17 +590,15 @@ impl ChunkingContext for BrowserChunkingContext {
                             let content = asset.content().await?;
                             if let AssetContent::File(file) = &*content {
                                 let content_hash = hash_xxh3_hash64(&file.await?);
-                                filename = replace_content_hash_placeholder(
-                                    &filename,
-                                    &format!("{content_hash:016x}"),
-                                );
+                                let hash_str = format!("{content_hash:016x}");
+                                filename = replace_content_hash_placeholder(&filename, &hash_str);
                             } else {
                                 bail!(
                                     "chunk_path requires an asset with file content when content \
                                      hashing is enabled"
                                 );
                             }
-                        };
+                        }
 
                         filename
                     }
@@ -808,9 +806,10 @@ impl ChunkingContext for BrowserChunkingContext {
         module_graph: Vc<ModuleGraph>,
         input_availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
+        let ident_str = ident.to_string().await?;
         let span = tracing::info_span!(
             "chunking",
-            name = display(ident.to_string().await?),
+            name = display(ident_str.clone()),
             chunking_type = "evaluated",
         );
         async move {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueDefault, ValueToString, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, ValueDefault, ValueToString, Vc};
 use turbopack_core::chunk::{
     AsyncModuleInfo, Chunk, ChunkItem, ChunkItemBatchGroup, ChunkItemOrBatchWithAsyncModuleInfo,
     ChunkType, ChunkingContext, round_chunk_item_size,
@@ -35,12 +35,38 @@ impl ChunkType for EcmascriptChunkType {
         chunk_items: Vec<ChunkItemOrBatchWithAsyncModuleInfo>,
         batch_groups: Vec<ResolvedVc<ChunkItemBatchGroup>>,
     ) -> Result<Vc<Box<dyn Chunk>>> {
+        // Convert and sort chunk items by their content identifier for deterministic output
+        let mut chunk_items_with_ident: Vec<_> = chunk_items
+            .iter()
+            .map(|item| async move {
+                let ecma_item =
+                    EcmascriptChunkItemOrBatchWithAsyncInfo::from_chunk_item_or_batch(item).await?;
+                let ident_str = match &ecma_item {
+                    EcmascriptChunkItemOrBatchWithAsyncInfo::ChunkItem(item) => {
+                        item.chunk_item.content_ident().to_string().await?
+                    }
+                    EcmascriptChunkItemOrBatchWithAsyncInfo::Batch(batch) => {
+                        let batch_ref = batch.await?;
+                        if let Some(first_item) = batch_ref.chunk_items.first() {
+                            first_item.chunk_item.content_ident().to_string().await?
+                        } else {
+                            ReadRef::new_owned(RcStr::default())
+                        }
+                    }
+                };
+                Ok((ident_str, ecma_item))
+            })
+            .try_join()
+            .await?;
+
+        // Sort by identifier string for deterministic ordering
+        chunk_items_with_ident.sort_by(|a, b| a.0.cmp(&b.0));
+
         let content = EcmascriptChunkContent {
-            chunk_items: chunk_items
-                .iter()
-                .map(EcmascriptChunkItemOrBatchWithAsyncInfo::from_chunk_item_or_batch)
-                .try_join()
-                .await?,
+            chunk_items: chunk_items_with_ident
+                .into_iter()
+                .map(|(_, item)| item)
+                .collect(),
             batch_groups: batch_groups
                 .into_iter()
                 .map(|batch_group| {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -135,16 +135,24 @@ impl Chunk for EcmascriptChunk {
             }
         }
 
-        let assets = chunk_items
+        // Sort chunk items by their content identifier for deterministic asset ordering
+        let mut assets_with_sort_key: Vec<_> = chunk_items
             .iter()
             .map(|&chunk_item| async move {
-                Ok((
-                    rcstr!("chunk item"),
-                    chunk_item.content_ident().to_resolved().await?,
-                ))
+                let ident = chunk_item.content_ident().to_resolved().await?;
+                let ident_str = ident.to_string().await?;
+                Ok((ident, ident_str))
             })
             .try_join()
             .await?;
+
+        // Sort by identifier string
+        assets_with_sort_key.sort_by(|a, b| a.1.cmp(&b.1));
+
+        let assets: Vec<(RcStr, ResolvedVc<AssetIdent>)> = assets_with_sort_key
+            .into_iter()
+            .map(|(ident, _)| (rcstr!("chunk item"), ident))
+            .collect();
 
         let ident = AssetIdent {
             path: if let Some(common_path) = common_path {


### PR DESCRIPTION
This change sorts the module factories under Turbopack chunks based on their identifiers, referencing Webpack: https://github.com/webpack/webpack/blob/main/lib/util/comparators.js#L312-L319

This modification can achieve approximately 100% actual size reduction for some Turbopack build artifacts (the improvement is more significant in larger projects):

Before:

<img width="3840" height="2028" alt="image" src="https://github.com/user-attachments/assets/fbe1ab12-6175-40f0-997e-fecd29c5e140" />

After:

<img width="3840" height="2030" alt="image" src="https://github.com/user-attachments/assets/b8c7c167-ec2a-457d-9762-b41ea049e6c6" />

The principle here is that (I haven't yet created a minimal reproducible demo), Umi's SPA applications import route paths via dynamic imports:

- Route A asynchronously loads modules [X, Y, Z]
- Route B asynchronously loads modules [Z, X, Y]

Then, when generating chunks:

- modules = [X, Y, Z] -> ident hash = abc123 -> chunk_abc123.js
- modules = [Z, X, Y] -> ident hash = def456 -> chunk_def456.js

However, the module content of these two chunks is actually identical; essentially, they are two identical chunks. Therefore, we directly sort the modules under `modules` based on `moduleId` or similar criteria, ensuring that the modules within the chunk remain stable:

- modules = [X, Y, Z] → sort → [X, Y, Z] → ident hash = abc123 → chunk_abc123.js
- modules = [Z, X, Y] → sort → [X, Y, Z] → ident hash = abc123 → chunk_abc123.js

This way, when generating the chunk, it will be treated as a single chunk, thus saving a significant amount of chunk size overhead.

In practice, this should theoretically not affect the existing code logic, because currently it only sorts the modules of the JS chunk, but the actual code execution order is still determined by the dependencies in the dependency graph. Similarly, it will not affect module merging.

Here's a Webpack example:

```ts
// index.js
import "./module-a.js";
import "./module-c.js";
import "./module-d.js";
import "./module-b.js";

console.log("main");

// module-a.js
console.log("module a");

// module-b.js
console.log("module b");

// module-c.js
console.log("module c");

// module-d.js
console.log("module d");
```

When Webpack generates the `index.js` chunk, regardless of whether the import order is a, b, c, d or a, c, b, d, the corresponding module sorting is:

<img width="1844" height="1344" alt="image" src="https://github.com/user-attachments/assets/4fd5d92f-f6e8-4117-ae3a-2a868d48d35e" />

The modules are sorted according to their module chunk ID names (a->b->c->d), so this should also be applicable to Turbopack.

Related issue: https://github.com/utooland/utoo/issues/2477