### PR TITLE
feat(turbopack): sort for module factory ident under chunk generate

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -366,14 +366,13 @@ impl DiskWatcher {
             return false;
         }
         path.components().any(|component| {
-            if let Component::Normal(name) = component {
-                if let Some(name_str) = name.to_str() {
+            if let Component::Normal(name) = component
+                && let Some(name_str) = name.to_str() {
                     return self
                         .ignored_paths
                         .iter()
                         .any(|ignored| ignored.as_str() == name_str);
                 }
-            }
             false
         })
     }

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -267,10 +267,21 @@ impl AssetIdent {
             fragment.deterministic_hash(&mut hasher);
             has_hash = true;
         }
-        for (key, ident) in assets.iter() {
+        if !assets.is_empty() {
+            // Use XOR to combine asset hashes in an order-independent way
+            // This ensures chunks with the same modules but different order get the same hash
+            let mut combined_asset_hash = 0u64;
+            for (key, ident) in assets.iter() {
+                let mut asset_hasher = Xxh3Hash64Hasher::new();
+                key.deterministic_hash(&mut asset_hasher);
+                ident
+                    .to_string()
+                    .await?
+                    .deterministic_hash(&mut asset_hasher);
+                combined_asset_hash ^= asset_hasher.finish();
+            }
             2_u8.deterministic_hash(&mut hasher);
-            key.deterministic_hash(&mut hasher);
-            ident.to_string().await?.deterministic_hash(&mut hasher);
+            combined_asset_hash.deterministic_hash(&mut hasher);
             has_hash = true;
         }
         for modifier in modifiers.iter() {

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -270,7 +270,7 @@ impl AssetIdent {
         if !assets.is_empty() {
             // Use XOR to combine asset hashes in an order-independent way
             // This ensures chunks with the same modules but different order get the same hash
-            let mut combined_asset_hash = 0u64;
+            let mut asset_hashes = Vec::with_capacity(assets.len());
             for (key, ident) in assets.iter() {
                 let mut asset_hasher = Xxh3Hash64Hasher::new();
                 key.deterministic_hash(&mut asset_hasher);
@@ -278,10 +278,14 @@ impl AssetIdent {
                     .to_string()
                     .await?
                     .deterministic_hash(&mut asset_hasher);
-                combined_asset_hash ^= asset_hasher.finish();
+                asset_hashes.push(asset_hasher.finish());
             }
+            asset_hashes.sort_unstable();
+
             2_u8.deterministic_hash(&mut hasher);
-            combined_asset_hash.deterministic_hash(&mut hasher);
+            for h in asset_hashes {
+                h.deterministic_hash(&mut hasher);
+            }
             has_hash = true;
         }
         for modifier in modifiers.iter() {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -1,9 +1,10 @@
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueDefault, ValueToString, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, ValueDefault, ValueToString, Vc};
 use turbopack_core::chunk::{
-    AsyncModuleInfo, Chunk, ChunkItem, ChunkItemBatchGroup, ChunkItemOrBatchWithAsyncModuleInfo,
-    ChunkType, ChunkingContext, round_chunk_item_size,
+    AsyncModuleInfo, Chunk, ChunkItem, ChunkItemBatchGroup, ChunkItemExt,
+    ChunkItemOrBatchWithAsyncModuleInfo, ChunkType, ChunkingContext, ModuleId,
+    round_chunk_item_size,
 };
 
 use super::{EcmascriptChunk, EcmascriptChunkContent, EcmascriptChunkItem};
@@ -35,12 +36,45 @@ impl ChunkType for EcmascriptChunkType {
         chunk_items: Vec<ChunkItemOrBatchWithAsyncModuleInfo>,
         batch_groups: Vec<ResolvedVc<ChunkItemBatchGroup>>,
     ) -> Result<Vc<Box<dyn Chunk>>> {
+        // Convert chunk items first
+        let converted_chunk_items: Vec<_> = chunk_items
+            .iter()
+            .map(EcmascriptChunkItemOrBatchWithAsyncInfo::from_chunk_item_or_batch)
+            .try_join()
+            .await?;
+
+        // Sort chunk items by their module ID for deterministic content ordering
+        // This ensures chunks with the same modules produce identical content
+        let mut items_with_id: Vec<(usize, ReadRef<ModuleId>)> = converted_chunk_items
+            .iter()
+            .enumerate()
+            .map(|(idx, item)| async move {
+                let id: ReadRef<ModuleId> = match item {
+                    EcmascriptChunkItemOrBatchWithAsyncInfo::ChunkItem(item) => {
+                        (*item.chunk_item).id().await?
+                    }
+                    EcmascriptChunkItemOrBatchWithAsyncInfo::Batch(batch) => {
+                        let batch_ref = batch.await?;
+                        if let Some(first_item) = batch_ref.chunk_items.first() {
+                            (*first_item.chunk_item).id().await?
+                        } else {
+                            ReadRef::new_owned(ModuleId::String(RcStr::default()))
+                        }
+                    }
+                };
+                Ok((idx, id))
+            })
+            .try_join()
+            .await?;
+        items_with_id.sort_by(|a, b| a.1.cmp(&b.1));
+
+        let sorted_items: Vec<_> = items_with_id
+            .into_iter()
+            .map(|(idx, _)| converted_chunk_items[idx].clone())
+            .collect();
+
         let content = EcmascriptChunkContent {
-            chunk_items: chunk_items
-                .iter()
-                .map(EcmascriptChunkItemOrBatchWithAsyncInfo::from_chunk_item_or_batch)
-                .try_join()
-                .await?,
+            chunk_items: sorted_items,
             batch_groups: batch_groups
                 .into_iter()
                 .map(|batch_group| {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -45,11 +45,10 @@ impl ChunkType for EcmascriptChunkType {
 
         // Sort chunk items by their module ID for deterministic content ordering
         // This ensures chunks with the same modules produce identical content
-        let mut items_with_id: Vec<(usize, ReadRef<ModuleId>)> = converted_chunk_items
-            .iter()
-            .enumerate()
-            .map(|(idx, item)| async move {
-                let id: ReadRef<ModuleId> = match item {
+        let mut items_with_id: Vec<_> = converted_chunk_items
+            .into_iter()
+            .map(|item| async move {
+                let id: ReadRef<ModuleId> = match &item {
                     EcmascriptChunkItemOrBatchWithAsyncInfo::ChunkItem(item) => {
                         (*item.chunk_item).id().await?
                     }
@@ -62,16 +61,14 @@ impl ChunkType for EcmascriptChunkType {
                         }
                     }
                 };
-                Ok((idx, id))
+                Ok((id, item))
             })
             .try_join()
             .await?;
-        items_with_id.sort_by(|a, b| a.1.cmp(&b.1));
 
-        let sorted_items: Vec<_> = items_with_id
-            .into_iter()
-            .map(|(idx, _)| converted_chunk_items[idx].clone())
-            .collect();
+        items_with_id.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let sorted_items: Vec<_> = items_with_id.into_iter().map(|(_, item)| item).collect();
 
         let content = EcmascriptChunkContent {
             chunk_items: sorted_items,

--- a/turbopack/crates/turbopack-node/src/worker_pool/mod.rs
+++ b/turbopack/crates/turbopack-node/src/worker_pool/mod.rs
@@ -99,8 +99,7 @@ impl WorkerThreadPool {
 
             if let Some(worker_id) = idle.pop() {
                 return Ok((worker_id, AcquiredPermits::Idle { concurrency_permit }));
-            } else {
-            }
+            } 
         }
 
         let (tx, rx) = oneshot::channel();
@@ -110,8 +109,7 @@ impl WorkerThreadPool {
             let mut idle = self.state.idle_workers.lock();
             if let Some(worker_id) = idle.pop() {
                 return Ok((worker_id, AcquiredPermits::Idle { concurrency_permit }));
-            } else {
-            }
+            } 
             waiters.push(tx);
         }
 

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -159,9 +159,8 @@ impl EcmascriptChunkItem for StaticUrlJsChunkItem {
             .asset_url(self.static_asset.path().owned().await?, self.tag.clone())
             .await?;
 
-        let code = if asset_url.starts_with("__RUNTIME_PUBLIC_PATH__") {
+        let code = if let Some(asset_path) = asset_url.strip_prefix("__RUNTIME_PUBLIC_PATH__") {
             // For runtime publicPath, use the getPublicPath() runtime function
-            let asset_path = &asset_url["__RUNTIME_PUBLIC_PATH__".len()..];
             format!(
                 "{TURBOPACK_EXPORT_VALUE}({TURBOPACK_PUBLIC_PATH}() + {path});",
                 path = StringifyJs(asset_path)


### PR DESCRIPTION
for: https://github.com/utooland/next.js/pull/98

调整了 filename 的 hash 生成逻辑, contenthash 的生成还是根据 chunk_type 的 sort 来决定。

对比之前改动的性能劣化问题做出了优化，小型应用构建时间没有退步。



