### PR TITLE
feat(turbopack): support resolve windows absolute path with project_root

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -367,12 +367,13 @@ impl DiskWatcher {
         }
         path.components().any(|component| {
             if let Component::Normal(name) = component
-                && let Some(name_str) = name.to_str() {
-                    return self
-                        .ignored_paths
-                        .iter()
-                        .any(|ignored| ignored.as_str() == name_str);
-                }
+                && let Some(name_str) = name.to_str()
+            {
+                return self
+                    .ignored_paths
+                    .iter()
+                    .any(|ignored| ignored.as_str() == name_str);
+            }
             false
         })
     }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -20,7 +20,7 @@ use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt,
     TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs,
 };
-use turbo_tasks_fs::{FileSystemEntryType, FileSystemPath};
+use turbo_tasks_fs::{DiskFileSystem, FileSystemEntryType, FileSystemPath};
 use turbo_unix_path::normalize_request;
 
 use crate::{
@@ -2020,18 +2020,77 @@ async fn resolve_internal_inline(
                 .await?
             }
             Request::Windows {
-                path: _,
-                query: _,
-                fragment: _,
+                path,
+                query,
+                fragment,
             } => {
+                if let Some(path_str) = path.as_constant_string() {
+                    let sys_path = std::path::Path::new(path_str.as_str());
+
+                    if let Some(disk_fs_vc) =
+                        ResolvedVc::try_downcast_type::<DiskFileSystem>(lookup_path.fs)
+                    {
+                        let disk_fs = disk_fs_vc.await?;
+                        let root_path = lookup_path.root().owned().await?;
+
+                        // Try to convert the Windows path to a FileSystemPath
+                        if let Some(fs_path) = disk_fs.try_from_sys_path(disk_fs_vc, sys_path, None)
+                        {
+                            // Successfully converted - resolve as a raw path
+                            let mut results = Vec::new();
+                            let unix_path = &fs_path.path;
+                            let pattern = Pattern::Constant(unix_path.clone());
+                            let matches = read_matches(
+                                root_path.clone(),
+                                rcstr!(""),
+                                false,
+                                Pattern::new(pattern).resolve().await?,
+                            )
+                            .await?;
+
+                            for m in matches.iter() {
+                                match m {
+                                    PatternMatch::File(matched_pattern, path) => {
+                                        results.push(
+                                            resolved(
+                                                RequestKey::new(matched_pattern.clone()),
+                                                path.clone(),
+                                                lookup_path.clone(),
+                                                request,
+                                                options_value,
+                                                options,
+                                                query.clone(),
+                                                fragment.clone(),
+                                            )
+                                            .await?,
+                                        );
+                                    }
+                                    PatternMatch::Directory(matched_pattern, path) => {
+                                        results.push(
+                                            resolve_into_folder(path.clone(), options)
+                                                .with_request(matched_pattern.clone()),
+                                        );
+                                    }
+                                }
+                            }
+
+                            return Ok(merge_results(results));
+                        }
+                    }
+                }
+
                 if !has_alias {
                     ResolvingIssue {
                         severity: error_severity(options).await?,
-                        request_type: "windows import: not implemented yet".to_string(),
+                        request_type: "windows import".to_string(),
                         request: request.to_resolved().await?,
                         file_path: lookup_path.clone(),
                         resolve_options: options.to_resolved().await?,
-                        error_message: Some("windows imports are not implemented yet".to_string()),
+                        error_message: Some(
+                            "Windows absolute path imports can only be resolved if the path is \
+                             within the project root. Please use a relative path instead."
+                                .to_string(),
+                        ),
                         source: None,
                     }
                     .resolved_cell()

--- a/turbopack/crates/turbopack-node/src/worker_pool/mod.rs
+++ b/turbopack/crates/turbopack-node/src/worker_pool/mod.rs
@@ -99,7 +99,7 @@ impl WorkerThreadPool {
 
             if let Some(worker_id) = idle.pop() {
                 return Ok((worker_id, AcquiredPermits::Idle { concurrency_permit }));
-            } 
+            }
         }
 
         let (tx, rx) = oneshot::channel();
@@ -109,7 +109,7 @@ impl WorkerThreadPool {
             let mut idle = self.state.idle_workers.lock();
             if let Some(worker_id) = idle.pop() {
                 return Ok((worker_id, AcquiredPermits::Idle { concurrency_permit }));
-            } 
+            }
             waiters.push(tx);
         }
 


### PR DESCRIPTION
给 turbopack-resolve 支持解析 windows 下的绝对路径:

```ts
import something from "C:\\path\\to\\module.js";
```

如果绝对路径里面包含了项目的 project_path 支持解析，如果解析到项目路径外了，这种情况不支持解析。

ref issue: https://github.com/utooland/utoo/issues/2479