### PR TITLE
fix(turbopack-css): treat css url resolve error as warning

### DIFF
--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -79,7 +79,8 @@ impl ModuleReference for UrlAssetReference {
             *self.request,
             ReferenceType::Url(UrlReferenceSubType::CssUrl),
             Some(self.issue_source),
-            false,
+            // Treat as optional so that unresolved URLs emit warnings instead of errors
+            true,
         )
     }
 }


### PR DESCRIPTION
把 css 里面的 url resolve 按照 optional 的 resolve 去处理:

https://github.com/utooland/next.js/blob/utoo/turbopack/crates/turbopack-core/src/resolve/mod.rs#L3390-L3392

这样 resolve 解析不到时，当作 warning 处理而不是 error 处理，这对很多存量业务 case 会很友好。