### PR TITLE
fix(turbopack): alias resolve lost query param

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2969,6 +2969,12 @@ async fn resolve_import_map_result(
         ImportMapResult::Result(result) => Some(**result),
         ImportMapResult::Alias(request, alias_lookup_path) => {
             let request = **request;
+            // Preserve the query string from the original request (e.g., ?modules for CSS modules)
+            let request = if !query.is_empty() {
+                request.with_query(query.clone())
+            } else {
+                request
+            };
             let lookup_path = match alias_lookup_path {
                 Some(path) => path.clone(),
                 None => lookup_path,


### PR DESCRIPTION
User code:

```ts
import styles from '@/index.less';

styles;
```

alias config: 

```ts
alias: {
  '@/*': './intput/*'
}
```

Before:

```bash
import style from '@/index.less'
    ↓ (transform add `?modules`)
'@/index.less?modules'
    ↓ (alias resolve，query lost)
'./input/index.less'  ← without query `?modules`, lightningcss doesn't deal css as css modules
    ↓
style = void 0  ❌
```

After:

```bash
import style from '@/index.less'
    ↓ (transform add `?modules`)
'@/index.less?modules'
    ↓ (alias resolve，query keep)
'./input/index.less?modules'  ← `?modules` keep
    ↓
style = { nav: "index-less__xxx__nav" }  ✅
```
