### PR TITLE
feat(turbopack): support entryRootExport config

### DIFF
--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -101,6 +101,11 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
+    pub fn entry_root_export(mut self, name: Option<RcStr>) -> Self {
+        self.chunking_context.entry_root_export = name;
+        self
+    }
+
     pub fn tracing(mut self, enable_tracing: bool) -> Self {
         self.chunking_context.enable_tracing = enable_tracing;
         self
@@ -336,6 +341,11 @@ pub struct BrowserChunkingContext {
     /// The global variable name used for chunk loading.
     /// Default: "TURBOPACK"
     chunk_loading_global: Option<RcStr>,
+    /// Expose entry module exports to global scope with the specified name.
+    /// When set, all named exports from the entry module will be available on
+    /// `window`/`globalThis` under the specified name.
+    /// Default: None (no exposure)
+    entry_root_export: Option<RcStr>,
 }
 
 impl BrowserChunkingContext {
@@ -386,6 +396,7 @@ impl BrowserChunkingContext {
                 filename: Default::default(),
                 chunk_filename: Default::default(),
                 chunk_loading_global: Default::default(),
+                entry_root_export: None,
             },
         }
     }
@@ -498,6 +509,12 @@ impl BrowserChunkingContext {
                 .clone()
                 .unwrap_or_else(|| rcstr!("TURBOPACK")),
         )
+    }
+
+    /// Returns the entry root export name to expose to global scope.
+    #[turbo_tasks::function]
+    pub fn entry_root_export(&self) -> Vc<Option<RcStr>> {
+        Vc::cell(self.entry_root_export.clone())
     }
 
     /// Returns the chunk path information.

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -199,6 +199,7 @@ impl EcmascriptBrowserEvaluateChunk {
                     output_root_to_root_path,
                     source_maps,
                     this.chunking_context.chunk_loading_global(),
+                    this.chunking_context.entry_root_export(),
                 );
                 code.push_code(&*runtime_code.await?);
             }

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
@@ -25,6 +25,7 @@ pub async fn get_browser_runtime_code(
     output_root_to_root_path: RcStr,
     generate_source_map: bool,
     chunk_loading_global: Vc<RcStr>,
+    entry_root_export: Vc<Option<RcStr>>,
 ) -> Result<Vc<Code>> {
     let asset_context = get_runtime_asset_context(*environment).resolve().await?;
 
@@ -86,23 +87,57 @@ pub async fn get_browser_runtime_code(
     let chunk_suffix = chunk_suffix.await?;
     let chunk_loading_global = chunk_loading_global.await?;
     let chunk_lists_global = format!("{}_CHUNK_LISTS", &*chunk_loading_global);
+    let entry_root_export = entry_root_export.await?;
 
-    writedoc!(
-        code,
-        r#"
-            (() => {{
-            if (!Array.isArray(globalThis["{chunk_loading_global}"])) {{
-                return;
-            }}
+    // Start the IIFE
+    if let Some(ref export_name) = *entry_root_export {
+        writedoc!(
+            code,
+            r#"
+                (function(root, factory) {{
+                    if (typeof exports === 'object' && typeof module === 'object')
+                        module.exports = factory();
+                    else if (typeof exports === 'object')
+                        exports[{}] = factory();
+                    else
+                        root[{}] = factory();
+                }}(typeof self !== 'undefined' ? self : this, function() {{
+                
+                const __chunk__ = (() => {{
+                if (!Array.isArray(globalThis["{chunk_loading_global}"])) {{
+                    return;
+                }}
 
-            const CHUNK_BASE_PATH = {};
-            const RELATIVE_ROOT_PATH = {};
-            const RUNTIME_PUBLIC_PATH = {};
-        "#,
-        StringifyJs(chunk_base_path),
-        StringifyJs(relative_root_path.as_str()),
-        StringifyJs(chunk_base_path),
-    )?;
+                let __entryExports__ = undefined;
+
+                const CHUNK_BASE_PATH = {};
+                const RELATIVE_ROOT_PATH = {};
+                const RUNTIME_PUBLIC_PATH = {};
+            "#,
+            StringifyJs(export_name.as_str()),
+            StringifyJs(export_name.as_str()),
+            StringifyJs(chunk_base_path),
+            StringifyJs(relative_root_path.as_str()),
+            StringifyJs(chunk_base_path),
+        )?;
+    } else {
+        writedoc!(
+            code,
+            r#"
+                (() => {{
+                if (!Array.isArray(globalThis["{chunk_loading_global}"])) {{
+                    return;
+                }}
+
+                const CHUNK_BASE_PATH = {};
+                const RELATIVE_ROOT_PATH = {};
+                const RUNTIME_PUBLIC_PATH = {};
+            "#,
+            StringifyJs(chunk_base_path),
+            StringifyJs(relative_root_path.as_str()),
+            StringifyJs(chunk_base_path),
+        )?;
+    }
 
     match &*chunk_suffix {
         ChunkSuffix::None => {
@@ -196,12 +231,59 @@ pub async fn get_browser_runtime_code(
         "#
         )?;
     }
-    writedoc!(
-        code,
-        r#"
+
+    // Add expose entry exports code if enabled
+    if entry_root_export.is_some() {
+        writedoc!(
+            code,
+            r#"
+                
+                try {{
+                for (const registration of chunksToRegister) {{
+                    const runtimeParams = registration.length === 2 ? registration[1] : null;
+                    if (runtimeParams && runtimeParams.runtimeModuleIds && runtimeParams.runtimeModuleIds.length > 0) {{
+                        const entryModuleId = runtimeParams.runtimeModuleIds[runtimeParams.runtimeModuleIds.length - 1];
+                        const chunkPath = getPathFromScript(registration[0]);
+                        
+                        const entryModule = getOrInstantiateRuntimeModule(chunkPath, entryModuleId);
+                        
+                        if (entryModule && entryModule.exports) {{
+                            const moduleExports = entryModule.namespaceObject || entryModule.exports;
+                            
+                            // Save for return value (will be handled by UMD wrapper)
+                            __entryExports__ = moduleExports;
+                        }}
+                        break;
+                    }}
+                }}
+                }} catch (e) {{
+                    console.error('Failed to expose entry module exports:', e);
+                }}
+            "#
+        )?;
+    }
+
+    // Close the IIFE and return exports if enabled
+    if entry_root_export.is_some() {
+        writedoc!(
+            code,
+            r#"
+                return __entryExports__;
             }})();
-        "#
-    )?;
+
+            // Return the exports from the factory function
+            return __chunk__;
+            }}));
+            "#
+        )?;
+    } else {
+        writedoc!(
+            code,
+            r#"
+            }})();
+            "#
+        )?;
+    }
 
     Ok(Code::cell(code.build()))
 }


### PR DESCRIPTION
支持 `exposeEntryExports` 配置。为了解决 issue: https://github.com/utooland/utoo/issues/2532

qiankun 需要子应用在 entry chunk 暴露出对应的运行时函数: https://qiankun.umijs.org/zh/guide/tutorial#%E5%BE%AE%E5%BA%94%E7%94%A8

在 webpack 场景下，qiankun 子应用通常处理方式为把应用构造成 library 的形式(一般是 umd 格式):

<img width="3174" height="862" alt="image" src="https://github.com/user-attachments/assets/fbe92adb-1c84-43cd-b251-5e201b21abf6" />

webpack 的 library 产物格式支持入口函数的导出，参考文档: https://webpack.js.org/configuration/output/#outputlibrary

但目前 utoopack / turbopack 并不支持这种 library 形式的输出(utoopack 的 library umd 仅支持 bundle 出一个 single chunk)。

为了适配这里 qiankun 子应用的函数导出，这里有两个方案:

- 在 umi 下添加一个 qiankun-slave-utoopack 的 plugin，按照 qiankun 非 webpack bundle 的方式去构造一个 runtime chunk 通过 `<script>` 提前加载进去(https://github.com/umijs/umi/blob/master/packages/plugins/src/qiankun/slave.ts#L197-L203) 评估过后发现这里 umi / qiankun 逻辑耦合比较深，改不动

- utoopack 的 app 构建添加一个配置叫 `exposeEntryExports` 来通过运行时构造把 entry chunk 里面的一些函数导出给从 entry chunk 里面导出出去:

<img width="2560" height="1220" alt="image" src="https://github.com/user-attachments/assets/9d0ef1e0-4cea-4c4a-b910-e948b6a1dc6b" />


