### PR TITLE
fix(turbopack): use chunkPath instead chunk object under register stage

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/runtime-backend-dom.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/runtime-backend-dom.ts
@@ -39,7 +39,7 @@ const chunkResolvers: Map<ChunkUrl, ChunkResolver> = new Map()
   BACKEND = {
     async registerChunk(chunk, params) {
       let chunkPath = getPathFromScript(chunk)
-      let chunkUrl = getUrlFromScript(chunk)
+      let chunkUrl = getUrlFromScript(chunkPath)
 
       const resolver = getOrCreateResolver(chunkUrl)
       resolver.resolve()


### PR DESCRIPTION
<img width="2006" height="1278" alt="image" src="https://github.com/user-attachments/assets/607d4407-f75f-41cc-bc84-21651572b422" />


因为 utoopack 需要支持 runtime 的 publicPath, 在 getUrlFromScript 参数为 string 的时候才会去做publicPath url 的拼接

适配一下 PR: https://github.com/vercel/next.js/pull/88899