### PR TITLE
fix(turbopack):  simplify script externals chunk name

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -295,10 +295,9 @@ impl Module for CachedExternalModule {
         // For script externals, simplify the path by using variable name
         // instead of the full url to avoid long filenames
         let path_str = if self.external_type == CachedExternalType::Script
-            && let Some(at_index) = self.request.find('@')
+            && let Some(at_index) = self.request.rfind('@').filter(|&i| i > 0)
         {
-            let variable_name = &self.request[..at_index];
-            variable_name.to_string()
+            self.request[..at_index].to_string()
         } else {
             self.request.to_string()
         };

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -292,7 +292,17 @@ fn externals_fs_root() -> Vc<FileSystemPath> {
 impl Module for CachedExternalModule {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
-        let mut ident = AssetIdent::from_path(externals_fs_root().await?.join(&self.request)?)
+        // For script externals, simplify the path by using variable name
+        // instead of the full url to avoid long filenames
+        let path_str = if self.external_type == CachedExternalType::Script
+            && let Some(at_index) = self.request.find('@')
+        {
+            let variable_name = &self.request[..at_index];
+            variable_name.to_string()
+        } else {
+            self.request.to_string()
+        };
+        let mut ident = AssetIdent::from_path(externals_fs_root().await?.join(&path_str)?)
             .with_layer(Layer::new(rcstr!("external")))
             .with_modifier(self.request.clone())
             .with_modifier(self.external_type.to_string().into());


### PR DESCRIPTION
简化当 externals 配置为 script 时候生成 chunk 的产物名称:

Before:

<img width="1772" height="300" alt="image" src="https://github.com/user-attachments/assets/593e08db-e7fe-40cc-9a38-368ac596bc72" />


After:

<img width="1816" height="302" alt="image" src="https://github.com/user-attachments/assets/f42d8fe0-ad53-458c-a0d3-8b7a50c952f9" />