### PR TITLE
fix(turbopack): merged alias lost module factory for missing type import

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1135,8 +1135,14 @@ impl EcmascriptModuleContent {
                 .try_join()
                 .await?;
 
-            let (merged_ast, comments, source_maps, original_source_maps, lookup_table) =
-                merge_modules(contents, &entry_points, &globals_merged).await?;
+            let (
+                merged_ast,
+                comments,
+                source_maps,
+                original_source_maps,
+                lookup_table,
+                fallback_import_idents,
+            ) = merge_modules(contents, &entry_points, &globals_merged).await?;
 
             // Use the options from an arbitrary module, since they should all be the same with
             // regards to minify_type and chunking_context.
@@ -1165,22 +1171,35 @@ impl EcmascriptModuleContent {
             };
 
             let first_entry = entry_points.first().unwrap().0;
-            let additional_ids = modules
-                .keys()
-                // Additionally set this module factory for all modules that are exposed. The whole
-                // group might be imported via a different entry import in different chunks (we only
-                // ensure that the modules are in the same order, not that they form a subgraph that
-                // is always imported from the same root module).
-                //
-                // Also skip the first entry, which is the name of the chunk item.
-                .filter(|m| {
-                    **m != first_entry
-                        && *modules.get(*m).unwrap() == MergeableModuleExposure::External
+            let module_ids = modules
+                .iter()
+                .map(async |(module, exposure)| {
+                    Ok((
+                        *module,
+                        *exposure,
+                        module.chunk_item_id(*options.chunking_context).await?,
+                    ))
                 })
-                .map(|m| m.chunk_item_id(*options.chunking_context))
                 .try_join()
-                .await?
-                .into();
+                .await?;
+            let additional_ids = module_ids
+                .into_iter()
+                .filter_map(|(module, exposure, module_id)| {
+                    if module == first_entry {
+                        return None;
+                    }
+                    let fallback_ident: Atom =
+                        crate::magic_identifier::mangle(&format!("imported module {module_id}"))
+                            .into();
+                    if exposure == MergeableModuleExposure::External
+                        || fallback_import_idents.contains(&fallback_ident)
+                    {
+                        Some(module_id)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<SmallVec<[ModuleId; 1]>>();
 
             emit_content(content, additional_ids)
                 .instrument(tracing::info_span!("emit code"))
@@ -1214,6 +1233,7 @@ async fn merge_modules(
     Vec<CodeGenResultSourceMap>,
     SmallVec<[ResolvedVc<Box<dyn GenerateSourceMap>>; 1]>,
     Arc<Mutex<Vec<ModulePosition>>>,
+    FxHashSet<Atom>,
 )> {
     struct SetSyntaxContextVisitor<'a> {
         modules_header_width: u32,
@@ -1513,10 +1533,12 @@ async fn merge_modules(
         merged_ast.visit_mut_with(&mut swc_core::ecma::transforms::base::hygiene::hygiene());
         drop(span);
 
-        Ok((merged_ast, inserted))
+        let fallback_import_idents = inserted_imports.keys().cloned().collect();
+
+        Ok((merged_ast, inserted, fallback_import_idents))
     });
 
-    let (merged_ast, inserted) = match result {
+    let (merged_ast, inserted, fallback_import_idents) = match result {
         Ok(v) => v,
         Err((content_idx, err)) => {
             return Err(
@@ -1563,6 +1585,7 @@ async fn merge_modules(
         source_maps,
         original_source_maps,
         Arc::new(Mutex::new(lookup_table)),
+        fallback_import_idents,
     ))
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -286,7 +286,6 @@ impl EcmascriptInputTransform {
                     legacy: *is_legacy,
                     emit_metadata: *emit_decorators_metadata,
                     use_define_for_class_fields: *use_define_for_class_fields,
-                    ..Default::default()
                 };
 
                 apply_transform(program, helpers, decorators(config))


### PR DESCRIPTION
fix scope hoisting with missing export type binding cause module factory lost:

<img width="1286" height="544" alt="image" src="https://github.com/user-attachments/assets/ce171af0-d958-491f-bcd3-db0db63817c1" />