### PR TITLE
fix(turbopack): OOM fast path for WASM + bump tokio-fs-ext 0.7.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3074,7 +3074,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5763,7 +5763,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5801,7 +5801,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8974,9 +8974,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-fs-ext"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912f3435ecb4330fed82d1b3a8cddf6354ea6472d40fadfb9063a3e9da1c6dec"
+checksum = "db902ff0804cc7965a81fec91151b9c27ed3a489c217a5dc7a885064fb0c1571"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -233,6 +233,25 @@ where
             StorageWriteGuard<'e>,
         ),
     ) {
+        // Fast path: no backing storage (e.g. WASM/NoopKvDb) — process inline,
+        // skip the Vec allocation needed for batch DB restoration.
+        if !self.backend.should_restore() {
+            for (id, category) in task_ids {
+                let mut task = self.backend.storage.access_mut(id);
+                if !task.flags.is_restored(category) {
+                    task.flags.set_restored(category);
+                }
+                if id.is_transient() {
+                    if call_prepared_task_callback_for_transient_tasks {
+                        prepared_task_callback(self, id, category, task);
+                    }
+                } else {
+                    prepared_task_callback(self, id, category, task);
+                }
+            }
+            return;
+        }
+
         let mut data_count = 0;
         let mut meta_count = 0;
         let mut all_count = 0;

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -57,7 +57,7 @@ notify-types = { workspace = true }
 notify = { workspace = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-tokio-fs-ext = { version = "0.7.7", features = ["opfs_offload", "opfs_watch"] }
+tokio-fs-ext = { version = "0.7.8", features = ["opfs_offload", "opfs_watch"] }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }


### PR DESCRIPTION
- Add no-restore fast path in `prepare_tasks_with_callback` to skip Vec allocation in WASM/NoopKvDb
- Bump `tokio-fs-ext` to 0.7.8 in `turbo-tasks-fs` (stale dir handle retry fix)