### PR TITLE
TURBOPACK: disable swc compress sequences

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -100,6 +100,9 @@ pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Resu
                                 passes: 2,
                                 keep_classnames: mangle.is_none(),
                                 keep_fnames: mangle.is_none(),
+                                // TODO @fireairforce: this is a workaround for the issue
+                                sequences: 0,
+                                // join_vars: false,
                                 ..Default::default()
                             }),
                             mangle: mangle.map(|mangle| {


### PR DESCRIPTION
fix: 

<img width="1946" height="1030" alt="image" src="https://github.com/user-attachments/assets/4a0b8443-1049-4e59-a93c-2f15487a7f40" />

now i don't have a good idea for that case(can't build a minimal reproduce), it's just a workaround, it seems the Chinese character cause swc minify panic(the rust case as follows):


```rs
#[cfg(test)]
mod tests {
    use std::panic::{AssertUnwindSafe, catch_unwind};

    use swc_core::{
        atoms::Wtf8Atom,
        common::DUMMY_SP,
        ecma::ast::{Expr, ExprStmt, Lit, Stmt, Str},
    };

    fn is_directive_like(e: &Stmt) -> bool {
        match e {
            Stmt::Expr(s) => match &*s.expr {
                Expr::Lit(Lit::Str(Str { value, .. })) => value.starts_with("use "),
                _ => false,
            },
            _ => false,
        }
    }

    #[test]
    fn directive_check_panics_on_non_ascii_literal() {
        let stmt = Stmt::Expr(ExprStmt {
            span: DUMMY_SP,
            expr: Box::new(Expr::Lit(Lit::Str(Str {
                span: DUMMY_SP,
                value: Wtf8Atom::from("汉字"),
                raw: None,
            }))),
        });

        let result = catch_unwind(AssertUnwindSafe(|| {
            let _ = is_directive_like(&stmt);
        }));

        assert!(result.is_err(), "expected non-ASCII directive panic");
    }
}
```