### PR TITLE
TURBPACK: recognize windows absoulte path

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -90,7 +90,8 @@ fn split_off_query_fragment(mut raw: &str) -> (Pattern, RcStr, RcStr) {
     (Pattern::Constant(RcStr::from(raw)), query, hash)
 }
 
-static WINDOWS_PATH: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[A-Za-z]:\\|\\\\").unwrap());
+static WINDOWS_PATH: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[A-Za-z]:[/\\]|^\\\\").unwrap());
 static URI_PATH: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^([^/\\:]+:)(.+)$").unwrap());
 static DATA_URI_REMAINDER: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^([^;,]*)(?:;([^,]+))?,(.*)$").unwrap());
@@ -863,6 +864,27 @@ pub async fn stringify_data_uri(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_windows_paths() {
+        assert_eq!(
+            Request::Windows {
+                path: rcstr!(r"C:\Users\demo\src\index.ts").into(),
+                query: rcstr!(""),
+                fragment: rcstr!(""),
+            },
+            Request::parse_ref(rcstr!(r"C:\Users\demo\src\index.ts").into())
+        );
+
+        assert_eq!(
+            Request::Windows {
+                path: rcstr!("C:/Users/demo/src/index.ts").into(),
+                query: rcstr!(""),
+                fragment: rcstr!(""),
+            },
+            Request::parse_ref(rcstr!("C:/Users/demo/src/index.ts").into())
+        );
+    }
 
     #[test]
     fn test_parse_module() {


### PR DESCRIPTION
turbopack should recognize windows path like:

```ts
import 'C:/Users/zoomdong/antd-pro/src/global.less';
```

Now it cause panic(which has been recognized as externals request):

<img width="1832" height="1630" alt="image" src="https://github.com/user-attachments/assets/7ab99d47-058b-4b82-920e-3d03a0035244" />
