### PR TITLE
feat(turbopack): wasm file write support and available_parallelism for worker pool

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1115,6 +1115,7 @@ impl FileSystem for DiskFileSystem {
                     return Ok(());
                 }
 
+                #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
                 match &*self.content {
                     FileContent::Content(..) => {
                         let create_directory = compare == FileComparison::Create;
@@ -1177,6 +1178,37 @@ impl FileSystem for DiskFileSystem {
                                     Err(err)
                                 }
                             })
+                            .with_context(|| format!("removing {full_path:?} failed"))?;
+                    }
+                }
+
+                #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+                match &*self.content {
+                    FileContent::Content(..) => {
+                        let create_directory = compare == FileComparison::Create;
+                        if create_directory && let Some(parent) = full_path.parent() {
+                            self.inner.create_directory(parent).await.with_context(|| {
+                                format!(
+                                    "failed to create directory {parent:?} for write to \
+                                     {full_path:?}",
+                                )
+                            })?;
+                        }
+                        let content = self.content.clone();
+                        let FileContent::Content(file) = &*content else {
+                            unreachable!()
+                        };
+                        wasm_fs_offload::CLIENT
+                            .write(&full_path, file.content().to_bytes())
+                            .instrument(tracing::info_span!("write file", name = ?full_path))
+                            .await
+                            .with_context(|| format!("failed to write to {full_path:?}"))?;
+                    }
+                    FileContent::NotFound => {
+                        wasm_fs_offload::CLIENT
+                            .remove_file(&full_path)
+                            .instrument(tracing::info_span!("remove file", name = ?full_path))
+                            .await
                             .with_context(|| format!("removing {full_path:?} failed"))?;
                     }
                 }

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -1,7 +1,4 @@
-use std::{
-    borrow::Cow, iter, process::ExitStatus, sync::Arc, thread::available_parallelism,
-    time::Duration,
-};
+use std::{borrow::Cow, iter, process::ExitStatus, sync::Arc, time::Duration};
 
 use anyhow::{Result, bail};
 use bincode::{Decode, Encode};
@@ -45,6 +42,7 @@ use crate::process_pool::ChildProcessPool;
 use crate::worker_pool::WorkerThreadPool;
 use crate::{
     AssetsForSourceMapping,
+    available_parallelism::available_parallelism,
     backend::{CreatePoolOptions, NodeBackend},
     embed_js::embed_file_path,
     emit, emit_package_json,
@@ -275,7 +273,7 @@ pub async fn get_evaluate_pool(
             assets_for_source_mapping,
             assets_root: output_root.clone(),
             project_dir: chunking_context.root_path().owned().await?,
-            concurrency: available_parallelism().map_or(1, |v| v.get()),
+            concurrency: available_parallelism(),
             debug,
         })
         .await?;

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -13,6 +13,7 @@ use turbopack_core::{
     virtual_output::VirtualOutputAsset,
 };
 
+mod available_parallelism;
 mod backend;
 pub mod debug;
 pub mod embed_js;


### PR DESCRIPTION
## Changes

### turbo-tasks-fs
- Add wasm32-specific file write/remove path via `wasm_fs_offload` client, gated behind `#[cfg(all(target_family = "wasm", target_os = "unknown"))]`
- Fix symlink error message formatting

### turbopack-node
- Extract `available_parallelism` into a dedicated module for cross-platform concurrency detection
- Simplify `get_evaluate_pool` to use `available_parallelism()` directly instead of `available_parallelism().map_or(1, |v| v.get())`
- Clean up import formatting in `evaluate.rs`