### PR TITLE
TURBOPACK: expose node ecmascript chunk types and accessors

### DIFF
--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/mod.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/mod.rs
@@ -1,1 +1,5 @@
-pub(crate) mod node;
+pub mod node;
+
+pub use node::{
+    EcmascriptBuildNodeChunk, EcmascriptBuildNodeEntryChunk, EcmascriptBuildNodeRuntimeChunk,
+};

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -19,7 +19,7 @@ use crate::NodeJsChunkingContext;
 #[turbo_tasks::value(shared)]
 #[derive(ValueToString)]
 #[value_to_string("Ecmascript Build Node Chunk")]
-pub(crate) struct EcmascriptBuildNodeChunk {
+pub struct EcmascriptBuildNodeChunk {
     chunking_context: ResolvedVc<NodeJsChunkingContext>,
     chunk: ResolvedVc<EcmascriptChunk>,
 }
@@ -65,6 +65,11 @@ impl EcmascriptBuildNodeChunk {
             this.chunk.chunk_content(),
             self.source_map(),
         ))
+    }
+
+    #[turbo_tasks::function]
+    pub fn chunk(&self) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(*self.chunk)
     }
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{ResolvedVc, ValueToString, Vc, turbobail};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkingContext, EvaluatableAssets, ModuleChunkItemIdExt},
+    chunk::{ChunkData, ChunkingContext, ChunksData, EvaluatableAssets, ModuleChunkItemIdExt},
     code_builder::{Code, CodeBuilder},
     module_graph::ModuleGraph,
     output::{
@@ -25,7 +25,7 @@ use crate::NodeJsChunkingContext;
 #[turbo_tasks::value(shared)]
 #[derive(ValueToString)]
 #[value_to_string("Ecmascript Build Node Entry Chunk")]
-pub(crate) struct EcmascriptBuildNodeEntryChunk {
+pub struct EcmascriptBuildNodeEntryChunk {
     path: FileSystemPath,
     other_chunks: ResolvedVc<OutputAssets>,
     evaluatable_assets: ResolvedVc<EvaluatableAssets>,
@@ -61,6 +61,29 @@ impl EcmascriptBuildNodeEntryChunk {
             chunking_context,
         }
         .cell()
+    }
+
+    #[turbo_tasks::function]
+    pub async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+        Ok(ChunkData::from_assets(
+            self.chunking_context.output_root().owned().await?,
+            *self.other_chunks,
+        ))
+    }
+
+    #[turbo_tasks::function]
+    pub fn evaluatable_assets(&self) -> Vc<EvaluatableAssets> {
+        *self.evaluatable_assets
+    }
+
+    #[turbo_tasks::function]
+    pub fn module_graph(&self) -> Vc<ModuleGraph> {
+        *self.module_graph
+    }
+
+    #[turbo_tasks::function]
+    pub fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        Vc::upcast(*self.chunking_context)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/mod.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/mod.rs
@@ -1,2 +1,2 @@
-pub(crate) mod chunk;
-pub(crate) mod runtime;
+pub mod chunk;
+pub mod runtime;

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -22,7 +22,7 @@ use crate::NodeJsChunkingContext;
 #[turbo_tasks::value(shared)]
 #[derive(ValueToString)]
 #[value_to_string("Ecmascript Build Node Runtime Chunk")]
-pub(crate) struct EcmascriptBuildNodeRuntimeChunk {
+pub struct EcmascriptBuildNodeRuntimeChunk {
     chunking_context: ResolvedVc<NodeJsChunkingContext>,
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/mod.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/mod.rs
@@ -1,5 +1,8 @@
-pub(crate) mod chunk;
+pub mod chunk;
 pub(crate) mod content;
-pub(crate) mod entry;
+pub mod entry;
 pub(crate) mod update;
 pub(crate) mod version;
+
+pub use chunk::EcmascriptBuildNodeChunk;
+pub use entry::{chunk::EcmascriptBuildNodeEntryChunk, runtime::EcmascriptBuildNodeRuntimeChunk};

--- a/turbopack/crates/turbopack-nodejs/src/lib.rs
+++ b/turbopack/crates/turbopack-nodejs/src/lib.rs
@@ -2,6 +2,9 @@
 #![feature(arbitrary_self_types_pointers)]
 
 pub(crate) mod chunking_context;
-pub(crate) mod ecmascript;
+pub mod ecmascript;
 
 pub use chunking_context::{NodeJsChunkingContext, NodeJsChunkingContextBuilder};
+pub use ecmascript::{
+    EcmascriptBuildNodeChunk, EcmascriptBuildNodeEntryChunk, EcmascriptBuildNodeRuntimeChunk,
+};


### PR DESCRIPTION
Promote `EcmascriptBuildNodeChunk`, `EcmascriptBuildNodeEntryChunk`, and `EcmascriptBuildNodeRuntimeChunk` from `pub(crate)` to `pub`, and re-export them from `turbopack_nodejs`, mirroring the browser-side visibility.

Add public accessors needed for downstream consumers (e.g. webpack-compatible stats generation):
- `EcmascriptBuildNodeChunk::chunk()` — exposes the inner `Chunk` for chunk_items
- `EcmascriptBuildNodeEntryChunk::chunks_data()` / `evaluatable_assets()` / `module_graph()` / `chunking_context()` — mirror `EcmascriptBrowserEvaluateChunk`

No behavior changes inside turbopack-nodejs itself.
