### PR TITLE
feat(turbopack): Support auto public path in Turbopack runtime

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/runtime-base.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/runtime-base.ts
@@ -36,10 +36,13 @@ declare var ASSET_SUFFIX: string
 declare var CROSS_ORIGIN: 'anonymous' | 'use-credentials' | null
 declare var WORKER_FORWARDED_GLOBALS: string[]
 
-// Support runtime public path from window.publicPath
+// Support runtime public path modes.
 function getRuntimeChunkBasePath(basePath: string = CHUNK_BASE_PATH): string {
-  if (CHUNK_BASE_PATH === '__RUNTIME_PUBLIC_PATH__') {
+  if (basePath === '__RUNTIME_PUBLIC_PATH__') {
     return contextPrototype.p()
+  }
+  if (basePath === '__AUTO_PUBLIC_PATH__') {
+    return contextPrototype.p('auto')
   }
   return basePath
 }

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/runtime-types.d.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/runtime-types.d.ts
@@ -104,7 +104,7 @@ type GetWorkerURL = (
   shared: boolean
 ) => URL
 
-type GetPublicPath = () => string
+type GetPublicPath = (mode?: 'auto') => string
 
 type ExternalRequire = (
   id: DependencySpecifier,

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/runtime-utils.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/runtime-utils.ts
@@ -834,11 +834,53 @@ contextPrototype.z = requireStub
 // Make `globalThis` available to the module in a way that cannot be shadowed by a local variable.
 contextPrototype.g = globalThis
 
+let cachedAutomaticPublicPath: string | undefined
+
+function getAutomaticPublicPath(): string {
+  if (cachedAutomaticPublicPath !== undefined) {
+    return cachedAutomaticPublicPath
+  }
+
+  let scriptUrl: string | undefined
+  if (typeof document === 'object') {
+    const currentScript = document.currentScript as HTMLScriptElement | null
+    scriptUrl = currentScript?.src
+
+    if (!scriptUrl) {
+      const scripts = document.getElementsByTagName('script')
+      const script = scripts[scripts.length - 1]
+      scriptUrl = script?.src
+    }
+  }
+
+  if (
+    !scriptUrl &&
+    typeof (globalThis as any).importScripts === 'function' &&
+    (globalThis as any).location
+  ) {
+    scriptUrl = String((globalThis as any).location)
+  }
+
+  cachedAutomaticPublicPath = scriptUrl
+    ? scriptUrl
+        .replace(/^blob:/, '')
+        .replace(/#.*$/, '')
+        .replace(/\?.*$/, '')
+        .replace(/\/[^/]*$/, '/')
+    : ''
+
+  return cachedAutomaticPublicPath
+}
+
 /**
  * Gets the public path for runtime assets.
  * Checks globalThis.publicPath and falls back to empty string.
  */
-function getPublicPath(): string {
+function getPublicPath(mode?: 'auto'): string {
+  if (mode === 'auto') {
+    return getAutomaticPublicPath()
+  }
+
   if (
     typeof globalThis !== 'undefined' &&
     typeof (globalThis as any).publicPath === 'string'

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -117,6 +117,17 @@ impl EcmascriptChunkPlaceable for StaticUrlJsModule {
             }
             .cell());
         }
+        if let Some(asset_path) = url.strip_prefix("__AUTO_PUBLIC_PATH__") {
+            let code = format!(
+                "{TURBOPACK_EXPORT_VALUE}({TURBOPACK_PUBLIC_PATH}(\"auto\") + {path});",
+                path = StringifyJs(asset_path)
+            );
+            return Ok(EcmascriptChunkItemContent {
+                inner_code: code.into(),
+                ..Default::default()
+            }
+            .cell());
+        }
 
         let url_behavior = chunking_context.url_behavior(this.tag.clone()).await?;
 


### PR DESCRIPTION
## Summary

- add an automatic public path mode for Turbopack runtime chunk loading
- infer the public path from the current script URL and cache it for runtime asset loading
- allow static asset modules to use the same automatic public path marker

## Why

UtooPack needs webpack-compatible `output.publicPath: "auto"` behavior so chunks and asset module URLs can resolve relative to where the runtime script is actually served from.

## Validation

- `cargo test -p pack-tests public_path -- --nocapture` from the utoo checkout
- `cargo fmt` from the utoo checkout
- `cargo clippy --all-targets -- -D warnings --no-deps` from the utoo checkout
- submodule pre-commit lint-staged hooks
