### PR TITLE
fix(turbopack): skip webpack loaders for css urls

### DIFF
--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -457,6 +457,9 @@ impl ModuleOptions {
                     )
                 }
 
+                rule_conditions.push(RuleCondition::not(RuleCondition::ReferenceType(
+                    ReferenceTypeCondition::Url(Some(UrlReferenceSubType::CssUrl)),
+                )));
                 rule_conditions.push(RuleCondition::not(RuleCondition::ResourceIsVirtualSource));
                 rule_conditions.push(module_css_external_transform_conditions.clone());
 


### PR DESCRIPTION
## Summary

- exclude `ReferenceType::Url(CssUrl)` when expanding configured webpack loader rules
- let CSS `url()` assets continue through the static URL asset path instead of being transformed by JS/SVGR-style loaders

## Context

This matches webpack issuer behavior used by Umi's SVGR rule: SVGs imported from JS/TS can use SVGR/loaders, while SVGs referenced from CSS `url()` remain static assets.

## Tests

- `git -C next.js diff --check`
- `cargo fmt --manifest-path next.js/turbopack/crates/turbopack/Cargo.toml`
- lint-staged ran `rustfmt --edition 2024 --` during commit