### PR TITLE
fix(wasm): Enable mimalloc allocator for wasm

### DIFF
--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -10,36 +10,21 @@ autobenches = false
 bench = false
 
 [dependencies]
-
-[target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
-mimalloc = { version = "0.1.48", features = [
-  "extended",
-  "local_dynamic_tls",
-  "v3",
-], optional = true }
-
-[target.'cfg(all(target_os = "linux", not(target_family = "wasm")))'.dependencies]
-mimalloc = { version = "0.1.48", features = [
-  "extended",
-  "local_dynamic_tls",
-  "v3",
-], optional = true }
-
-[target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
-mimalloc = { version = "0.1.48", features = [
-  "extended",
-  "v3",
-], optional = true }
-
-[target.'cfg(not(any(target_os = "linux", target_family = "wasm")))'.dependencies]
-mimalloc = { version = "0.1.48", features = [
-  "extended",
-  "v3",
-], optional = true }
-
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
 libmimalloc-sys = { version = "0.1.44", features = [
   "extended",
+], optional = true }
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+mimalloc = { version = "0.1.48", features = [
+  "extended",
+  "v3",
+], optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+mimalloc = { version = "0.1.48", features = [
+  "extended",
+  "local_dynamic_tls",
+  "v3",
 ], optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -104,11 +104,11 @@ impl TurboMalloc {
     /// force=true: do all the work of `process=false` and then process global shared structures and
     /// return memory to the OS if possible, this is much slower and should only be done rarely.
     pub fn collect(force: bool) {
-        #[cfg(all(feature = "custom_allocator", not(target_family = "wasm")))]
+        #[cfg(feature = "custom_allocator")]
         unsafe {
             libmimalloc_sys::mi_collect(force);
         }
-        #[cfg(not(all(feature = "custom_allocator", not(target_family = "wasm"))))]
+        #[cfg(not(feature = "custom_allocator"))]
         {
             let _ = force;
         }
@@ -143,17 +143,17 @@ impl TurboMalloc {
 /// Get the allocator for this platform that we should wrap with TurboMalloc.
 #[inline]
 fn base_alloc() -> &'static impl GlobalAlloc {
-    #[cfg(all(feature = "custom_allocator", not(target_family = "wasm")))]
+    #[cfg(feature = "custom_allocator")]
     return &mimalloc::MiMalloc;
-    #[cfg(any(not(feature = "custom_allocator"), target_family = "wasm"))]
+    #[cfg(not(feature = "custom_allocator"))]
     return &std::alloc::System;
 }
 
 #[allow(unused_variables)]
 unsafe fn base_alloc_size(ptr: *const u8, layout: Layout) -> usize {
-    #[cfg(all(feature = "custom_allocator", not(target_family = "wasm")))]
+    #[cfg(feature = "custom_allocator")]
     return unsafe { mimalloc::MiMalloc.usable_size(ptr) };
-    #[cfg(any(not(feature = "custom_allocator"), target_family = "wasm"))]
+    #[cfg(not(feature = "custom_allocator"))]
     return layout.size();
 }
 


### PR DESCRIPTION
## Summary

- Simplify `turbo-tasks-malloc` mimalloc target dependency cfgs.
- Allow the custom allocator code paths to be gated only by the `custom_allocator` feature.
- Keep the diff scoped to `turbo-tasks-malloc`.

## Why

This aligns the allocator wrapper with the wasm-facing mimalloc exports used by Utoo's WASM build and avoids excluding the custom allocator paths only because the target family is wasm.

## Validation

- `cargo fmt -p turbo-tasks-malloc --check`
- `cargo clippy -p turbo-tasks-malloc --all-targets -- -D warnings --no-deps`
- `npx tombi format --check turbopack/crates/turbo-tasks-malloc/Cargo.toml`