### PR TITLE
feat(turbopack): add css runtime chunk fallback for css chunk

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/runtime-backend-dom.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/runtime-backend-dom.ts
@@ -144,6 +144,28 @@ const chunkResolvers: Map<ChunkUrl, ChunkResolver> = new Map()
       resolver.loadingStarted = true
 
       if (isCss(chunkUrl)) {
+        if (typeof importScripts !== 'function') {
+          const decodedChunkUrl = decodeURI(chunkUrl)
+          const previousLinks = document.querySelectorAll(
+            `link[rel=stylesheet][href="${chunkUrl}"],link[rel=stylesheet][href^="${chunkUrl}?"],link[rel=stylesheet][href="${decodedChunkUrl}"],link[rel=stylesheet][href^="${decodedChunkUrl}?"]`
+          )
+
+          if (previousLinks.length === 0) {
+            const link = document.createElement('link')
+            link.rel = 'stylesheet'
+            link.crossOrigin = CROSS_ORIGIN
+            link.href = chunkUrl
+            link.onerror = () => {
+              resolver.reject()
+            }
+            link.onload = () => {
+              resolver.resolve()
+            }
+            document.head.appendChild(link)
+            return resolver.promise
+          }
+        }
+
         resolver.resolve()
         return resolver.promise
       }


### PR DESCRIPTION
add same fallback logic for css initial runtime chunk just as js runtime chunk does, for minow proxy.