### PR TITLE
fix(turbopack): avoid scattered collect on wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,10 @@ console-subscriber = "0.4.1"
 const_format = "0.2.30"
 crc32fast = "1.5.0"
 criterion = { package = "codspeed-criterion-compat", version = "4.3.0" }
-ctor = "1.0.7"
+ctor = { version = "1.0.7", default-features = false, features = [
+  "std",
+  "proc_macro",
+] }
 crossbeam-channel = "0.5.8"
 crossbeam-utils = "0.8"
 dashmap = "6.1.0"

--- a/turbopack/crates/turbo-tasks-macros/src/ident.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/ident.rs
@@ -16,7 +16,7 @@ pub fn get_trait_type_ident(ident: &Ident) -> Ident {
 }
 
 /// Name of the per-trait `VTableRegistry` static, populated during `register_all_trait_methods`
-/// from the link-time `TRAIT_IMPLS_SLICE`.
+/// from the link-time registry.
 pub fn get_trait_vtable_registry_ident(ident: &Ident) -> Ident {
     Ident::new(&format!("__TurboTasksVTableRegistry_{ident}"), ident.span())
 }

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -285,8 +285,8 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             }
         }
         quote! {
-            // Register this `impl Trait for Concrete` into the link-time `TRAIT_IMPLS_SLICE`.
-            #[cfg(not(rust_analyzer))]
+            // Register this `impl Trait for Concrete` into the link-time registry.
+            #[cfg(not(target_family = "wasm"))]
             turbo_tasks::macro_helpers::scattered_collect::declarative::scatter! {
                 #[scatter(turbo_tasks::macro_helpers::TRAIT_IMPLS_SLICE)]
                 const _: turbo_tasks::macro_helpers::TraitImplRecord = {
@@ -306,6 +306,26 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         },
                     }
                 };
+            }
+            #[cfg(target_family = "wasm")]
+            turbo_tasks::macro_helpers::inventory_submit! {
+                {
+                    const LEN: usize = <::std::boxed::Box<dyn #trait_path> as turbo_tasks::macro_helpers::TraitVtablePrototype>::LEN;
+                    static METHODS: [&turbo_tasks::macro_helpers::NativeFunction; LEN] = turbo_tasks::macro_helpers::build_trait_vtable::<::std::boxed::Box<dyn #trait_path>, LEN>(&[#(#trait_methods),*]);
+
+                    turbo_tasks::macro_helpers::TraitImplRecord {
+                        value_type: <#ty as turbo_tasks::macro_helpers::RegistryDef::<turbo_tasks::ValueType>>::DEF,
+                        trait_type: <::std::boxed::Box<dyn #trait_path> as turbo_tasks::macro_helpers::RegistryDef::<turbo_tasks::TraitType>>::DEF,
+                        methods: &METHODS,
+                        install_vtable: |id: turbo_tasks::ValueTypeId| {
+                            // Materialize the vtable pointer via the null-fat-ptr trick.
+                            let p: *const #ty = ::std::ptr::null();
+                            let fat: *const dyn #trait_path = p;
+                            <::std::boxed::Box<dyn #trait_path> as turbo_tasks::VcValueTrait>::IMPL_VTABLES
+                                .insert(id, turbo_tasks::macro_helpers::metadata(fat));
+                        },
+                    }
+                }
             }
 
             // NOTE(alexkirsz) We can't have a general `turbo_tasks::Upcast<Box<dyn Trait>> for T where T: Trait` because

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -343,8 +343,8 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         // Per-trait `VTableRegistry`, populated during `register_all_trait_methods` (inside the
-        // `VALUES` `LazyLock` init) from the link-time `TRAIT_IMPLS_SLICE`. `const`-constructible,
-        // so no `LazyLock` / first-access init of its own. Kept private — the only reference is
+        // `VALUES` `LazyLock` init) from the link-time registry. `const`-constructible, so no
+        // `LazyLock` / first-access init of its own. Kept private — the only reference is
         // from the `VcValueTrait::IMPL_VTABLES` assoc const below.
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -41,7 +41,6 @@ pin-project-lite = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
-scattered-collect = { workspace = true }
 serde = { workspace = true, features = ["rc", "derive"] }
 serde_json = { workspace = true }
 shrink-to-fit = { workspace = true, features = [
@@ -77,6 +76,9 @@ tokio = { workspace = true }
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 js-sys = { version = "0.3.78" }
 wasm-bindgen = { version = "0.2.104" }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+scattered-collect = { workspace = true }
 
 [[bench]]
 name = "mod"

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -7,8 +7,11 @@ use std::{
 
 pub use async_trait::async_trait;
 pub use bincode;
+pub use inventory;
 use rustc_hash::FxHashMap;
+#[cfg(not(target_family = "wasm"))]
 pub use scattered_collect;
+#[cfg(not(target_family = "wasm"))]
 use scattered_collect::slice::ScatteredSlice;
 pub use shrink_to_fit;
 pub use tracing;
@@ -22,7 +25,7 @@ use crate::{
 pub use crate::{
     dyn_task_inputs::DynTaskInputs,
     global_name_for_method, global_name_for_scope, global_name_for_trait_method,
-    global_name_for_trait_method_impl, global_name_for_type,
+    global_name_for_trait_method_impl, global_name_for_type, inventory_submit,
     manager::{find_cell_by_id, find_cell_by_type, spawn_detached_for_testing},
     native_function::{
         ArgMeta, NativeFunction, VTABLE_DEFAULT, downcast_args_owned, downcast_args_ref,
@@ -243,8 +246,7 @@ where
     }
 }
 
-/// One `impl Trait for ConcreteType` registration, gathered at link time into
-/// [`TRAIT_IMPLS_SLICE`].
+/// One `impl Trait for ConcreteType` registration, gathered at link time.
 pub struct TraitImplRecord {
     pub value_type: &'static ValueType,
     pub trait_type: &'static TraitType,
@@ -254,15 +256,31 @@ pub struct TraitImplRecord {
     pub install_vtable: fn(ValueTypeId),
 }
 
-// Link-time collection of every `impl Trait for Concrete`. Like the definition slices in
-// `registry`, this is populated by the linker — complete at process start, no constructors, no
-// ordering. It is iterated exactly once, in `register_all_trait_methods`.
-//
-// `pub` so the `value_impl`-emitted scatter (which expands in downstream crates) can name it as
-// `$crate::macro_helpers::TRAIT_IMPLS_SLICE`; the data is `#[doc(hidden)]`.
+#[cfg(not(target_family = "wasm"))]
 #[doc(hidden)]
 #[scattered_collect::gather]
 pub static TRAIT_IMPLS_SLICE: ScatteredSlice<TraitImplRecord>;
+
+#[cfg(target_family = "wasm")]
+inventory::collect! { TraitImplRecord }
+
+/// Submit an item to the inventory.
+///
+/// This macro is a wrapper around `inventory::submit` that adds a
+/// `#[not(cfg(rust_analyzer))]` attribute to the item. This avoids warnings about unused items
+/// when using Rust Analyzer.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! inventory_submit {
+    ($($item:tt)*) => {
+        #[cfg(not(rust_analyzer))]
+        $crate::macro_helpers::inventory_submit_inner! { $($item)* }
+    };
+}
+
+/// Exported so the above macro can reference it.
+#[doc(hidden)]
+pub use inventory::submit as inventory_submit_inner;
 
 /// Use `type_name` to get globally unique identifier that's stable across multiple executions of
 /// the same Turbopack version, potentially allowing cache sharing across platforms/architectures.

--- a/turbopack/crates/turbo-tasks/src/registry/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/registry/mod.rs
@@ -1,6 +1,7 @@
 use std::{cell::SyncUnsafeCell, num::NonZeroU16, sync::LazyLock};
 
 use anyhow::Error;
+#[cfg(not(target_family = "wasm"))]
 use scattered_collect::slice::ScatteredSlice;
 
 use crate::{
@@ -42,43 +43,58 @@ macro_rules! impl_ptr_identity {
 
 pub(crate) use impl_ptr_identity;
 
-// Link-time gather slices, one per registry.
+#[cfg(not(target_family = "wasm"))]
 #[doc(hidden)]
 #[scattered_collect::gather]
 pub static FUNCTIONS_SLICE: ScatteredSlice<&'static NativeFunction>;
 
+#[cfg(not(target_family = "wasm"))]
 #[doc(hidden)]
 #[scattered_collect::gather]
 pub static VALUES_SLICE: ScatteredSlice<&'static ValueType>;
 
+#[cfg(not(target_family = "wasm"))]
 #[doc(hidden)]
 #[scattered_collect::gather]
 pub static TRAITS_SLICE: ScatteredSlice<&'static TraitType>;
 
-/// Register a [`NativeFunction`] definition into the link-time [`FUNCTIONS_SLICE`].
+#[cfg(target_family = "wasm")]
+inventory::collect!(&'static NativeFunction);
+#[cfg(target_family = "wasm")]
+inventory::collect!(&'static ValueType);
+#[cfg(target_family = "wasm")]
+inventory::collect!(&'static TraitType);
+
+/// Register a [`NativeFunction`] definition into the link-time registry.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! register_function {
     ($name:ident = $value:expr) => {
         static $name: $crate::macro_helpers::NativeFunction = $value;
+        #[cfg(not(target_family = "wasm"))]
         $crate::macro_helpers::scattered_collect::declarative::scatter! {
             #[scatter($crate::registry::FUNCTIONS_SLICE)]
             const _: &'static $crate::macro_helpers::NativeFunction = &$name;
         }
+        #[cfg(target_family = "wasm")]
+        $crate::macro_helpers::inventory_submit! { &$name }
     };
 }
 
-/// Register a [`ValueType`] definition into the link-time [`VALUES_SLICE`], and provide its
+/// Register a [`ValueType`] definition into the link-time registry, and provide its
 /// `RegistryDef` so the impl macros can recover the `&'static ValueType` for a Vc type.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! register_value {
     ($reg:ty => $name:ident = $value:expr) => {
         static $name: $crate::ValueType = $value;
+        #[cfg(not(target_family = "wasm"))]
         $crate::macro_helpers::scattered_collect::declarative::scatter! {
             #[scatter($crate::registry::VALUES_SLICE)]
             const _: &'static $crate::ValueType = &$name;
         }
+        #[cfg(target_family = "wasm")]
+        $crate::macro_helpers::inventory_submit! { &$name }
 
         impl $crate::macro_helpers::RegistryDef<$crate::ValueType> for $reg {
             const DEF: &'static $crate::ValueType = &$name;
@@ -86,17 +102,20 @@ macro_rules! register_value {
     };
 }
 
-/// Register a [`TraitType`] definition into the link-time [`TRAITS_SLICE`], and provide its
+/// Register a [`TraitType`] definition into the link-time registry, and provide its
 /// `RegistryDef` so the impl macros can recover the `&'static TraitType` for a `Box<dyn Trait>`.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! register_trait {
     ($reg:ty => $name:ident = $value:expr) => {
         static $name: $crate::TraitType = $value;
+        #[cfg(not(target_family = "wasm"))]
         $crate::macro_helpers::scattered_collect::declarative::scatter! {
             #[scatter($crate::registry::TRAITS_SLICE)]
             const _: &'static $crate::TraitType = &$name;
         }
+        #[cfg(target_family = "wasm")]
+        $crate::macro_helpers::inventory_submit! { &$name }
 
         impl $crate::macro_helpers::RegistryDef<$crate::TraitType> for $reg {
             const DEF: &'static $crate::TraitType = &$name;
@@ -233,8 +252,21 @@ fn validate_id<T: Registerable>(
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
+fn registered_functions() -> Vec<&'static NativeFunction> {
+    FUNCTIONS_SLICE.iter().copied().collect()
+}
+
+#[cfg(target_family = "wasm")]
+fn registered_functions() -> Vec<&'static NativeFunction> {
+    inventory::iter::<&'static NativeFunction>
+        .into_iter()
+        .copied()
+        .collect()
+}
+
 static FUNCTIONS: LazyLock<Box<[&'static NativeFunction]>> =
-    LazyLock::new(|| init_registry(FUNCTIONS_SLICE.iter().copied().collect()));
+    LazyLock::new(|| init_registry(registered_functions()));
 
 #[inline]
 pub fn get_native_function(id: FunctionId) -> &'static NativeFunction {
@@ -250,8 +282,21 @@ pub fn validate_function_id(id: FunctionId) -> Option<Error> {
     validate_id(&FUNCTIONS, id)
 }
 
+#[cfg(not(target_family = "wasm"))]
+fn registered_values() -> Vec<&'static ValueType> {
+    VALUES_SLICE.iter().copied().collect()
+}
+
+#[cfg(target_family = "wasm")]
+fn registered_values() -> Vec<&'static ValueType> {
+    inventory::iter::<&'static ValueType>
+        .into_iter()
+        .copied()
+        .collect()
+}
+
 static VALUES: LazyLock<Box<[&'static ValueType]>> = LazyLock::new(|| {
-    let items = init_registry(VALUES_SLICE.iter().copied().collect());
+    let items = init_registry(registered_values());
     crate::value_type::register_all_trait_methods();
     items
 });
@@ -289,8 +334,21 @@ pub(crate) fn trait_type_count() -> usize {
     TRAITS.len()
 }
 
+#[cfg(not(target_family = "wasm"))]
+fn registered_traits() -> Vec<&'static TraitType> {
+    TRAITS_SLICE.iter().copied().collect()
+}
+
+#[cfg(target_family = "wasm")]
+fn registered_traits() -> Vec<&'static TraitType> {
+    inventory::iter::<&'static TraitType>
+        .into_iter()
+        .copied()
+        .collect()
+}
+
 static TRAITS: LazyLock<Box<[&'static TraitType]>> =
-    LazyLock::new(|| init_registry(TRAITS_SLICE.iter().copied().collect()));
+    LazyLock::new(|| init_registry(registered_traits()));
 
 #[inline]
 pub fn get_trait_type_id(trait_type: &'static TraitType) -> TraitTypeId {

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -13,7 +13,7 @@ use crate::{
     RawVc, SharedReference, TaskPriority, VcValueType,
     dyn_task_inputs::any_as_encode,
     id::TraitTypeId,
-    macro_helpers::{NativeFunction, TRAIT_IMPLS_SLICE},
+    macro_helpers::NativeFunction,
     registry::{
         RegistryType, get_trait_type_id, get_value_type_id_unchecked, impl_ptr_identity,
         trait_type_count,
@@ -272,7 +272,12 @@ impl ValueType {
 // Called during ValueType registry post_init to register all trait methods.
 // Single-threaded during Lazy init.
 pub(crate) fn register_all_trait_methods() {
-    for entry in TRAIT_IMPLS_SLICE.iter() {
+    #[cfg(not(target_family = "wasm"))]
+    let trait_impls = crate::macro_helpers::TRAIT_IMPLS_SLICE.iter();
+    #[cfg(target_family = "wasm")]
+    let trait_impls = inventory::iter::<crate::macro_helpers::TraitImplRecord>;
+
+    for entry in trait_impls {
         for (i, impl_method) in entry.methods.iter().enumerate() {
             let trait_method = &entry.trait_type.methods[i];
             if trait_method.is_root != impl_method.is_root {


### PR DESCRIPTION
## Summary
- keep the native `turbo-tasks` registry path on `scattered-collect`
- use an `inventory` fallback only for wasm targets so `@utoo/web` does not import `env.read_custom_section`
- disable `ctor` default features while keeping `std` and `proc_macro`, avoiding the `priority -> link-section` path for wasm

## Context
- Upstream Turbopack change: https://github.com/vercel/next.js/pull/94503 migrated `turbo-tasks` registry collection to `scattered-collect`.
- `scattered-collect` depends on `link-section` on wasm, which requires the host-provided `env.read_custom_section` import. That breaks browser-side `@utoo/web` initialization under wasm-bindgen.

## Verification
- `cargo fmt`
- `cargo check -p turbo-tasks -p turbo-tasks-macros`
- `CC=/opt/homebrew/opt/llvm/bin/clang CXX=/opt/homebrew/opt/llvm/bin/clang++ cargo build -p utoo-wasm --target wasm32-unknown-unknown -Z build-std=panic_abort,std --profile release-local`
- `cargo tree -p utoo-wasm --target wasm32-unknown-unknown -i scattered-collect`
- `cargo tree -p utoo-wasm --target wasm32-unknown-unknown -i link-section`
- `cargo tree -p turbo-tasks --target aarch64-apple-darwin | rg -n "scattered-collect|link-section|inventory|ctor"`
- `cargo clippy -p turbo-tasks -p turbo-tasks-macros --all-targets -- -D warnings --no-deps`
- `cargo clippy --all-targets -- -D warnings --no-deps`
- `npm run build:local --workspace @utoo/web`