### PR TITLE
fix(turbopack): fallback runtime publicPath should be '/'

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/runtime-utils.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/runtime-utils.ts
@@ -683,7 +683,7 @@ function getAutomaticPublicPath(): string {
 
 /**
  * Gets the public path for runtime assets.
- * Checks globalThis.publicPath and falls back to empty string.
+ * Checks globalThis.publicPath and falls back to "/".
  */
 function getPublicPath(mode?: 'auto'): string {
   if (mode === 'auto') {
@@ -697,7 +697,7 @@ function getPublicPath(mode?: 'auto'): string {
     const publicPath = (globalThis as any).publicPath as string
     return publicPath.endsWith('/') ? publicPath : `${publicPath}/`
   }
-  return ''
+  return '/'
 }
 contextPrototype.p = getPublicPath
 

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -405,13 +405,28 @@ pub(crate) async fn config_loader_source(
         r#"
             import {{ pathToFileURL }} from 'node:url';
             import path from 'node:path';
+            import {{ createRequire }} from 'node:module';
 
             const configPath = path.join(process.cwd(), {config_path});
-            // Absolute paths don't work with ESM imports on Windows:
-            // https://github.com/nodejs/node/issues/31710
-            // convert it to a file:// URL, which works on all platforms
             const configUrl = pathToFileURL(configPath).toString();
-            const mod = await {TURBOPACK_EXTERNAL_IMPORT}(configUrl);
+            const requireConfig = createRequire(configUrl);
+            let mod;
+            try {{
+                mod = requireConfig(configPath);
+            }} catch (error) {{
+                if (
+                    error == null ||
+                    (error.code !== 'ERR_REQUIRE_ESM' &&
+                        error.code !== 'ERR_REQUIRE_ASYNC_MODULE')
+                ) {{
+                    throw error;
+                }}
+
+                // Absolute paths don't work with ESM imports on Windows:
+                // https://github.com/nodejs/node/issues/31710
+                // convert it to a file:// URL, which works on all platforms
+                mod = await {TURBOPACK_EXTERNAL_IMPORT}(configUrl);
+            }}
 
             export default mod.default ?? mod;
         "#,


### PR DESCRIPTION
otherwise when `global.publicPath` fallback  be undefined, will get runtime error:

<img width="3000" height="1552" alt="image" src="https://github.com/user-attachments/assets/131768fd-d294-4ee8-b14a-ab5b9588a379" />
